### PR TITLE
[Feat] 회원가입 기능 및 User 스키마 구현 (#3)

### DIFF
--- a/moba-backend/backend/package-lock.json
+++ b/moba-backend/backend/package-lock.json
@@ -35,6 +35,7 @@
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
@@ -2900,6 +2901,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/moba-backend/backend/package-lock.json
+++ b/moba-backend/backend/package-lock.json
@@ -19,6 +19,8 @@
         "@nestjs/swagger": "^11.2.0",
         "axios": "^1.12.2",
         "bcrypt": "^6.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2",
         "dotenv": "^17.2.3",
         "mongoose": "^8.19.1",
         "passport": "^0.7.0",
@@ -3151,6 +3153,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -4659,6 +4667,23 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7657,6 +7682,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.24",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.24.tgz",
+      "integrity": "sha512-l5IlyL9AONj4voSd7q9xkuQOL4u8Ty44puTic7J88CmdXkxfGsRfoVLXHCxppwehgpb/Chdb80FFehHqjN3ItQ==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10498,6 +10529,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/moba-backend/backend/package.json
+++ b/moba-backend/backend/package.json
@@ -46,6 +46,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",

--- a/moba-backend/backend/package.json
+++ b/moba-backend/backend/package.json
@@ -30,6 +30,8 @@
     "@nestjs/swagger": "^11.2.0",
     "axios": "^1.12.2",
     "bcrypt": "^6.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "dotenv": "^17.2.3",
     "mongoose": "^8.19.1",
     "passport": "^0.7.0",

--- a/moba-backend/backend/src/app.module.ts
+++ b/moba-backend/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { MoviesModule } from './movies/movies.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { MoviesModule } from './movies/movies.module';
       inject: [ConfigService],
     }),
     MoviesModule,
+    AuthModule,
   ],
 })
 export class AppModule {}

--- a/moba-backend/backend/src/auth/auth.controller.spec.ts
+++ b/moba-backend/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('auth')
+export class AuthController {}

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,4 +1,8 @@
 import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Auth')
 @Controller('auth')
-export class AuthController {}
+export class AuthController {
+  // 다음 단계에서 signup, login 라우트 추가 예정
+}

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -4,5 +4,5 @@ import { ApiTags } from '@nestjs/swagger';
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  // 다음 단계에서 signup, login 라우트 추가 예정
+    
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,8 +1,26 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+// src/auth/auth.controller.ts
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+import { SignupRequestDto } from './dto/signup-request.dto';
+import { UserResponseDto } from './dto/user-response.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-    
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('signup')
+  @ApiOperation({ summary: '회원가입', description: '새 사용자를 등록합니다.' })
+  @ApiResponse({ status: 201, type: UserResponseDto })
+  async signup(@Body() dto: SignupRequestDto): Promise<UserResponseDto> {
+    const user = await this.authService.signup(dto);
+
+    return {
+      _id: user._id?.toString() ?? '',         // ✅ unknown 오류 해결
+      email: user.email,
+      nickname: user.nickname,
+      createdAt: user.createdAt ?? new Date(), // ✅ createdAt 타입 오류 해결
+    };
+  }
 }

--- a/moba-backend/backend/src/auth/auth.module.ts
+++ b/moba-backend/backend/src/auth/auth.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class AuthModule {}

--- a/moba-backend/backend/src/auth/auth.module.ts
+++ b/moba-backend/backend/src/auth/auth.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
-@Module({})
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService]
+})
 export class AuthModule {}

--- a/moba-backend/backend/src/auth/auth.module.ts
+++ b/moba-backend/backend/src/auth/auth.module.ts
@@ -1,9 +1,15 @@
+// src/auth/auth.module.ts
 import { Module } from '@nestjs/common';
-import { AuthController } from './auth.controller';
+import { MongooseModule } from '@nestjs/mongoose';
 import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { User, UserSchema } from './schemas/user.schema';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]), // ✅ 추가
+  ],
   controllers: [AuthController],
-  providers: [AuthService]
+  providers: [AuthService],
 })
 export class AuthModule {}

--- a/moba-backend/backend/src/auth/auth.service.spec.ts
+++ b/moba-backend/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {}

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -1,4 +1,33 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ConflictException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import * as bcrypt from 'bcrypt';
+import { User } from './schemas/user.schema';
+import { SignupRequestDto } from './dto/signup-request.dto';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  constructor(@InjectModel(User.name) private readonly userModel: Model<User>) {}
+
+  async signup(dto: SignupRequestDto): Promise<User> {
+    const { email, password, nickname } = dto;
+
+    // 이미 존재하는 이메일인지 확인
+    const existingUser = await this.userModel.findOne({ email });
+    if (existingUser) {
+      throw new ConflictException('이미 가입된 이메일입니다.');
+    }
+
+    // 비밀번호 암호화
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    // 새 유저 생성
+    const newUser = new this.userModel({
+      email,
+      password: hashedPassword,
+      nickname,
+    });
+
+    return newUser.save();
+  }
+}

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -1,33 +1,31 @@
+// src/auth/auth.service.ts
 import { Injectable, ConflictException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import * as bcrypt from 'bcrypt';
-import { User } from './schemas/user.schema';
+import { User, UserDocument } from './schemas/user.schema';
 import { SignupRequestDto } from './dto/signup-request.dto';
 
 @Injectable()
 export class AuthService {
-  constructor(@InjectModel(User.name) private readonly userModel: Model<User>) {}
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+  ) {}
 
-  async signup(dto: SignupRequestDto): Promise<User> {
+  async signup(dto: SignupRequestDto): Promise<UserDocument> {
     const { email, password, nickname } = dto;
 
-    // 이미 존재하는 이메일인지 확인
-    const existingUser = await this.userModel.findOne({ email });
-    if (existingUser) {
-      throw new ConflictException('이미 가입된 이메일입니다.');
-    }
+    const exists = await this.userModel.findOne({ email });
+    if (exists) throw new ConflictException('이미 가입된 이메일입니다.');
 
-    // 비밀번호 암호화
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashed = await bcrypt.hash(password, 10);
 
-    // 새 유저 생성
-    const newUser = new this.userModel({
+    const user = await this.userModel.create({
       email,
-      password: hashedPassword,
+      password: hashed,
       nickname,
     });
 
-    return newUser.save();
+    return user; // UserDocument
   }
 }

--- a/moba-backend/backend/src/auth/dto/signup-request.dto.ts
+++ b/moba-backend/backend/src/auth/dto/signup-request.dto.ts
@@ -1,0 +1,18 @@
+// src/auth/dto/signup-request.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+
+export class SignupRequestDto {
+  @ApiProperty({ example: 'test@example.com', description: '회원 이메일' })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ example: '12345678', description: '비밀번호 (최소 8자)' })
+  @IsNotEmpty()
+  @MinLength(8)
+  password: string;
+
+  @ApiProperty({ example: '홍길동', description: '닉네임' })
+  @IsNotEmpty()
+  nickname: string;
+}

--- a/moba-backend/backend/src/auth/dto/user-response.dto.ts
+++ b/moba-backend/backend/src/auth/dto/user-response.dto.ts
@@ -1,0 +1,16 @@
+// src/auth/dto/user-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserResponseDto {
+  @ApiProperty({ example: '66e9488ad52f4b7a...', description: 'MongoDB 사용자 ID' })
+  _id: string;
+
+  @ApiProperty({ example: 'test@example.com', description: '회원 이메일' })
+  email: string;
+
+  @ApiProperty({ example: '홍길동', description: '닉네임' })
+  nickname: string;
+
+  @ApiProperty({ example: '2025-10-15T12:34:56Z', description: '가입일' })
+  createdAt: Date;
+}

--- a/moba-backend/backend/src/auth/schemas/user.schema.ts
+++ b/moba-backend/backend/src/auth/schemas/user.schema.ts
@@ -1,0 +1,17 @@
+// src/auth/schemas/user.schema.ts
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true }) // createdAt, updatedAt 자동 관리
+export class User extends Document {
+  @Prop({ required: true, unique: true })
+  email: string;
+
+  @Prop({ required: true })
+  password: string;
+
+  @Prop({ required: true })
+  nickname: string;
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);

--- a/moba-backend/backend/src/auth/schemas/user.schema.ts
+++ b/moba-backend/backend/src/auth/schemas/user.schema.ts
@@ -1,9 +1,11 @@
 // src/auth/schemas/user.schema.ts
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 
-@Schema({ timestamps: true }) // createdAt, updatedAt 자동 관리
-export class User extends Document {
+export type UserDocument = HydratedDocument<User>;
+
+@Schema({ timestamps: true })
+export class User {
   @Prop({ required: true, unique: true })
   email: string;
 
@@ -12,6 +14,11 @@ export class User extends Document {
 
   @Prop({ required: true })
   nickname: string;
+
+  //  TS 타입에 명시 (Mongoose가 자동 추가하지만 TS는 몰라서 오류 났던 부분)
+  _id?: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);


### PR DESCRIPTION


## ✨ Auth 회원가입 기능 구현

###  작업 브랜치
`feature/auth`

---

###  주요 변경 사항
- **회원가입 엔드포인트 추가**
  - `POST /auth/signup`
  - 이메일 중복 검증 (`ConflictException`)
  - 비밀번호 해싱(`bcrypt`)
  - 회원 생성 후 사용자 정보 반환

---

###  디렉토리 구조
```

src/
└── auth/
├── auth.controller.ts
├── auth.service.ts
├── dto/
│    ├── signup-request.dto.ts
│    └── user-response.dto.ts
└── schemas/
└── user.schema.ts

```

---

###  주요 구현 내용
- `UserSchema`: `email`, `password`, `nickname`, `timestamps` 정의  
- `AuthService.signup()`:  
  - 이메일 중복 시 `ConflictException` 발생  
  - 비밀번호 `bcrypt.hash()` 처리  
  - 신규 사용자 생성 후 반환  
- `AuthController.signup()`:  
  - Swagger 문서화 (`@ApiOperation`, `@ApiResponse`)  
  - DTO 기반 타입 안전성 강화  
  - `UserResponseDto`로 응답 변환

---

###  기술 스택 / 라이브러리
- NestJS  
- Mongoose  
- bcrypt  
- class-validator / class-transformer  
- Swagger (API 문서 자동화)

---

###  테스트 항목
- [x] 이메일 중복 시 409 Conflict 발생  
- [x] 정상 회원가입 시 201 Created 반환  
- [x] 비밀번호 암호화 저장 확인  
- [x] Swagger에서 회원가입 API 정상 노출 확인

---

###  추가 예정
- [ ] 로그인 로직 추가 (`POST /auth/login`)  
- [ ] JWT 발급 및 인증 가드 적용  
- [ ] Refresh Token 및 Profile 조회 기능 추가


