### PR TITLE
[feat] Auth 고도화 (JWT Access/Refresh + HttpOnly Cookie + CSRF) (#3)

### DIFF
--- a/moba-backend/backend/package-lock.json
+++ b/moba-backend/backend/package-lock.json
@@ -21,6 +21,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cookie-parser": "^1.4.7",
         "dotenv": "^17.2.3",
         "mongoose": "^8.19.1",
         "passport": "^0.7.0",
@@ -36,6 +37,7 @@
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
         "@types/bcrypt": "^6.0.0",
+        "@types/cookie-parser": "^1.4.8",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
@@ -2935,6 +2937,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -4999,6 +5011,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/moba-backend/backend/package-lock.json
+++ b/moba-backend/backend/package-lock.json
@@ -39,6 +39,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
+        "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -3084,6 +3085,38 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/moba-backend/backend/package.json
+++ b/moba-backend/backend/package.json
@@ -50,6 +50,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/moba-backend/backend/package.json
+++ b/moba-backend/backend/package.json
@@ -33,6 +33,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "dotenv": "^17.2.3",
+    "cookie-parser": "^1.4.7",
     "mongoose": "^8.19.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/moba-backend/backend/package.json
+++ b/moba-backend/backend/package.json
@@ -49,6 +49,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
+    "@types/cookie-parser": "^1.4.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -53,4 +53,13 @@ export class AuthController {
     };
   }
 
+  @Post('check-id')
+  @ApiOperation({ summary: '아이디 중복 확인', description: '입력한 아이디가 사용 가능한지 확인합니다.' })
+  @ApiResponse({ status: 200, description: '사용 가능' })
+  @ApiResponse({ status: 409, description: '이미 존재하는 아이디' })
+  async checkId(@Body('id') id: string) {
+    const exists = await this.authService.checkId(id);
+    return { available: !exists };
+  }
+
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, UseGuards, Req } from '@nestjs/common';
+import { Body, Controller, Get, Post, Put, Delete, UseGuards, Req } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupRequestDto } from './dto/signup-request.dto';
@@ -60,6 +60,16 @@ export class AuthController {
   async checkId(@Body('id') id: string) {
     const exists = await this.authService.checkId(id);
     return { available: !exists };
+  }
+
+  @Put('update')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '회원정보 수정', description: '닉네임 또는 비밀번호를 수정합니다.' })
+  async updateUser(@Req() req, @Body() dto: UpdateUserDto) {
+    const userId = req.user.id;
+    const result = await this.authService.updateUser(userId, dto);
+    return { message: '회원정보가 수정되었습니다.', updated: result };
   }
 
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, UseGuards, Req } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupRequestDto } from './dto/signup-request.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -33,6 +34,20 @@ export class AuthController {
   
     return {
       accessToken,
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+
+  @Get('protected')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'JWT 인증 확인', description: '로그인된 사용자 정보를 반환합니다.' })
+  @ApiResponse({ status: 200, description: '인증 성공' })
+  async getProtected(@Req() req) {
+    const user = req.user; // JwtStrategy.validate()에서 반환된 user
+    return {
+      message: `인증 성공`,
       id: user.id,
       nickname: user.nickname,
     };

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,4 +1,6 @@
-import { Body, Controller, Get, Post, Put, Delete, UseGuards, Req } from '@nestjs/common';
+import { 
+  Body, Controller, Get, Post, Put, UseGuards, Req, ConflictException, BadRequestException 
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupRequestDto } from './dto/signup-request.dto';
@@ -6,6 +8,7 @@ import { UserResponseDto } from './dto/user-response.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -17,7 +20,6 @@ export class AuthController {
   @ApiResponse({ status: 201, type: UserResponseDto })
   async signup(@Body() dto: SignupRequestDto): Promise<UserResponseDto> {
     const user = await this.authService.signup(dto);
-
     return {
       _id: user._id?.toString() ?? '',
       id: user.id,
@@ -31,7 +33,6 @@ export class AuthController {
   @ApiResponse({ status: 200, type: LoginResponseDto })
   async login(@Body() dto: LoginRequestDto): Promise<LoginResponseDto> {
     const { accessToken, user } = await this.authService.login(dto);
-  
     return {
       accessToken,
       id: user.id,
@@ -43,11 +44,10 @@ export class AuthController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'JWT 인증 확인', description: '로그인된 사용자 정보를 반환합니다.' })
-  @ApiResponse({ status: 200, description: '인증 성공' })
   async getProtected(@Req() req) {
-    const user = req.user; // JwtStrategy.validate()에서 반환된 user
+    const user = req.user;
     return {
-      message: `인증 성공`,
+      message: '인증 성공',
       id: user.id,
       nickname: user.nickname,
     };
@@ -55,21 +55,34 @@ export class AuthController {
 
   @Post('check-id')
   @ApiOperation({ summary: '아이디 중복 확인', description: '입력한 아이디가 사용 가능한지 확인합니다.' })
-  @ApiResponse({ status: 200, description: '사용 가능' })
-  @ApiResponse({ status: 409, description: '이미 존재하는 아이디' })
+  @ApiResponse({ status: 200, description: '사용 가능한 아이디입니다.' })
+  @ApiResponse({ status: 409, description: '이미 존재하는 아이디입니다.' })
   async checkId(@Body('id') id: string) {
+    if (!id?.trim()) {
+      throw new BadRequestException('아이디를 입력해주세요.');
+    }
+
     const exists = await this.authService.checkId(id);
-    return { available: !exists };
+    if (exists) {
+      throw new ConflictException('이미 존재하는 아이디입니다.');
+    }
+    return { available: true };
   }
 
   @Put('update')
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '회원정보 수정', description: '닉네임 또는 비밀번호를 수정합니다.' })
+  @ApiResponse({ status: 200, type: UserResponseDto })
   async updateUser(@Req() req, @Body() dto: UpdateUserDto) {
     const userId = req.user.id;
-    const result = await this.authService.updateUser(userId, dto);
-    return { message: '회원정보가 수정되었습니다.', updated: result };
-  }
+    const updated = await this.authService.updateUser(userId, dto);
 
+    return {
+      _id: updated._id?.toString() ?? '',
+      id: updated.id,
+      nickname: updated.nickname,
+      createdAt: updated.createdAt ?? new Date(),
+    };
+  }
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { 
-  Body, Controller, Get, Post, Put, UseGuards, Req, ConflictException, BadRequestException 
+  Body, Controller, Get, Post, Put, Delete, UseGuards, Req, ConflictException, BadRequestException 
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
@@ -44,6 +44,7 @@ export class AuthController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'JWT 인증 확인', description: '로그인된 사용자 정보를 반환합니다.' })
+  @ApiResponse({ status: 200, description: '인증 성공' })
   async getProtected(@Req() req) {
     const user = req.user;
     return {
@@ -84,5 +85,17 @@ export class AuthController {
       nickname: updated.nickname,
       createdAt: updated.createdAt ?? new Date(),
     };
+  }
+
+  @Delete('delete')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '회원 탈퇴', description: '현재 로그인된 사용자의 계정을 완전히 삭제합니다.' })
+  @ApiResponse({ status: 200, description: '회원 탈퇴 성공' })
+  @ApiResponse({ status: 404, description: '사용자를 찾을 수 없습니다.' })
+  async deleteUser(@Req() req) {
+    const userId = req.user.id;
+    await this.authService.deleteUser(userId);
+    return { message: '회원 탈퇴가 완료되었습니다.' };
   }
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -119,4 +119,22 @@ export class AuthController {
     await this.authService.deleteUser(userId);
     return { message: '회원 탈퇴가 완료되었습니다.' };
   }
+
+  @Post('logout')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '로그아웃', description: '쿠키와 서버 저장 리프레시 토큰을 무효화합니다.' })
+  @ApiResponse({ status: 200, description: '로그아웃 성공' })
+  async logout(@Req() req, @Res({ passthrough: true }) res) {
+    const userId = req.user.id;
+    await this.authService.logout(userId);
+    res.cookie('refreshToken', '', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/auth',
+      maxAge: 0,
+    });
+    return { message: '로그아웃 되었습니다.' };
+  }
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,9 +1,10 @@
-// src/auth/auth.controller.ts
 import { Body, Controller, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupRequestDto } from './dto/signup-request.dto';
 import { UserResponseDto } from './dto/user-response.dto';
+import { LoginRequestDto } from './dto/login-request.dto';
+import { LoginResponseDto } from './dto/login-response.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -17,10 +18,24 @@ export class AuthController {
     const user = await this.authService.signup(dto);
 
     return {
-      _id: user._id?.toString() ?? '',         // ✅ unknown 오류 해결
-      email: user.email,
+      _id: user._id?.toString() ?? '',
+      id: user.id,
       nickname: user.nickname,
-      createdAt: user.createdAt ?? new Date(), // ✅ createdAt 타입 오류 해결
+      createdAt: user.createdAt ?? new Date(),
     };
   }
+
+  @Post('login')
+  @ApiOperation({ summary: '로그인', description: 'JWT 토큰을 발급합니다.' })
+  @ApiResponse({ status: 200, type: LoginResponseDto })
+  async login(@Body() dto: LoginRequestDto): Promise<LoginResponseDto> {
+    const { accessToken, user } = await this.authService.login(dto);
+  
+    return {
+      accessToken,
+      id: user.id,
+      nickname: user.nickname,
+    };
+  }
+
 }

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { 
-  Body, Controller, Get, Post, Put, Delete, UseGuards, Req, Res, ConflictException, BadRequestException 
+  Body, Controller, Get, Post, Put, Delete, UseGuards, Req, Res, ConflictException, BadRequestException, UnauthorizedException 
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
@@ -41,6 +41,16 @@ export class AuthController {
       sameSite: 'lax',
       path: '/auth',
       maxAge: 14 * 24 * 60 * 60 * 1000, // 14d
+    });
+
+    // CSRF 토큰 발급(더블 서브밋: 쿠키+헤더 비교용)
+    const csrfToken = Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+    res.cookie('csrfToken', csrfToken, {
+      httpOnly: false, // 프론트에서 헤더로 실어 보낼 수 있어야 함
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 14 * 24 * 60 * 60 * 1000,
     });
 
     return {
@@ -102,6 +112,11 @@ export class AuthController {
   @ApiResponse({ status: 200, description: '새 Access Token 발급 성공' })
   @ApiResponse({ status: 401, description: '리프레시 토큰이 유효하지 않음' })
   async refresh(@Body('refreshToken') refreshToken: string, @Req() req) {
+    const headerToken = req.get('X-CSRF-Token');
+    const cookieToken = req.cookies?.csrfToken;
+    if (!headerToken || !cookieToken || headerToken !== cookieToken) {
+      throw new UnauthorizedException('CSRF token invalid');
+    }
     // 요청 본문이 우선, 없으면 쿠키에서 사용
     const token = refreshToken || req?.cookies?.refreshToken;
     const newAccessToken = await this.authService.refreshAccessToken(token);
@@ -126,6 +141,11 @@ export class AuthController {
   @ApiOperation({ summary: '로그아웃', description: '쿠키와 서버 저장 리프레시 토큰을 무효화합니다.' })
   @ApiResponse({ status: 200, description: '로그아웃 성공' })
   async logout(@Req() req, @Res({ passthrough: true }) res) {
+    const headerToken = req.get('X-CSRF-Token');
+    const cookieToken = req.cookies?.csrfToken;
+    if (!headerToken || !cookieToken || headerToken !== cookieToken) {
+      throw new UnauthorizedException('CSRF token invalid');
+    }
     const userId = req.user.id;
     await this.authService.logout(userId);
     res.cookie('refreshToken', '', {
@@ -133,6 +153,13 @@ export class AuthController {
       secure: true,
       sameSite: 'lax',
       path: '/auth',
+      maxAge: 0,
+    });
+    res.cookie('csrfToken', '', {
+      httpOnly: false,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
       maxAge: 0,
     });
     return { message: '로그아웃 되었습니다.' };

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -87,6 +87,15 @@ export class AuthController {
     };
   }
 
+  @Post('refresh')
+  @ApiOperation({ summary: 'Access Token 재발급', description: '리프레시 토큰으로 새 액세스 토큰을 발급합니다.' })
+  @ApiResponse({ status: 200, description: '새 Access Token 발급 성공' })
+  @ApiResponse({ status: 401, description: '리프레시 토큰이 유효하지 않음' })
+  async refresh(@Body('refreshToken') refreshToken: string) {
+    const newAccessToken = await this.authService.refreshAccessToken(refreshToken);
+    return { accessToken: newAccessToken };
+  }
+
   @Delete('delete')
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)

--- a/moba-backend/backend/src/auth/auth.controller.ts
+++ b/moba-backend/backend/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { 
-  Body, Controller, Get, Post, Put, Delete, UseGuards, Req, ConflictException, BadRequestException 
+  Body, Controller, Get, Post, Put, Delete, UseGuards, Req, Res, ConflictException, BadRequestException 
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
@@ -31,8 +31,18 @@ export class AuthController {
   @Post('login')
   @ApiOperation({ summary: '로그인', description: 'JWT 토큰을 발급합니다.' })
   @ApiResponse({ status: 200, type: LoginResponseDto })
-  async login(@Body() dto: LoginRequestDto): Promise<LoginResponseDto> {
-    const { accessToken, user } = await this.authService.login(dto);
+  async login(@Body() dto: LoginRequestDto, @Res({ passthrough: true }) res): Promise<LoginResponseDto> {
+    const { accessToken, refreshToken, user } = await this.authService.login(dto);
+
+    // HttpOnly 쿠키로 refresh 토큰 설정
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: true, // HTTPS 환경 권장
+      sameSite: 'lax',
+      path: '/auth',
+      maxAge: 14 * 24 * 60 * 60 * 1000, // 14d
+    });
+
     return {
       accessToken,
       id: user.id,
@@ -91,8 +101,10 @@ export class AuthController {
   @ApiOperation({ summary: 'Access Token 재발급', description: '리프레시 토큰으로 새 액세스 토큰을 발급합니다.' })
   @ApiResponse({ status: 200, description: '새 Access Token 발급 성공' })
   @ApiResponse({ status: 401, description: '리프레시 토큰이 유효하지 않음' })
-  async refresh(@Body('refreshToken') refreshToken: string) {
-    const newAccessToken = await this.authService.refreshAccessToken(refreshToken);
+  async refresh(@Body('refreshToken') refreshToken: string, @Req() req) {
+    // 요청 본문이 우선, 없으면 쿠키에서 사용
+    const token = refreshToken || req?.cookies?.refreshToken;
+    const newAccessToken = await this.authService.refreshAccessToken(token);
     return { accessToken: newAccessToken };
   }
 

--- a/moba-backend/backend/src/auth/auth.module.ts
+++ b/moba-backend/backend/src/auth/auth.module.ts
@@ -1,15 +1,34 @@
-// src/auth/auth.module.ts
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import type { StringValue } from 'ms';
 import { MongooseModule } from '@nestjs/mongoose';
-import { AuthService } from './auth.service';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 import { User, UserSchema } from './schemas/user.schema';
+import { JwtStrategy } from './strategies/jwt.strategy'; 
+import { JwtAuthGuard } from './guards/jwt-auth.guard'; 
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]), // ✅ 추가
+    ConfigModule,
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        const secret = configService.get<string>('JWT_SECRET') || 'default_secret';
+        const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') || '1h') as StringValue;
+        return {
+          secret,
+          signOptions: { expiresIn },
+        };
+      },
+    }),
   ],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard],
 })
 export class AuthModule {}

--- a/moba-backend/backend/src/auth/auth.module.ts
+++ b/moba-backend/backend/src/auth/auth.module.ts
@@ -19,7 +19,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const secret = configService.get<string>('JWT_SECRET') || 'default_secret';
+        const secret = configService.get<string>('JWT_ACCESS_SECRET') || 'default_access_secret';
         const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') || '1h') as StringValue;
         return {
           secret,

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -1,4 +1,6 @@
-import { Injectable, ConflictException, UnauthorizedException } from '@nestjs/common';
+import { 
+  Injectable, ConflictException, UnauthorizedException, NotFoundException, BadRequestException 
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import * as bcrypt from 'bcrypt';
@@ -6,6 +8,7 @@ import { JwtService } from '@nestjs/jwt';
 import { User, UserDocument } from './schemas/user.schema';
 import { SignupRequestDto } from './dto/signup-request.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class AuthService {
@@ -21,7 +24,6 @@ export class AuthService {
     if (exists) throw new ConflictException('이미 존재하는 아이디입니다.');
 
     const hashed = await bcrypt.hash(password, 10);
-
     const user = await this.userModel.create({
       id,
       password: hashed,
@@ -43,27 +45,37 @@ export class AuthService {
     const payload = { sub: user._id, id: user.id };
     const accessToken = this.jwtService.sign(payload);
 
-    return { accessToken, user }; // 유저 정보도 함께 반환
+    return { accessToken, user };
   }
 
   async checkId(id: string): Promise<boolean> {
     const user = await this.userModel.findOne({ id });
-    return !!user; // true면 이미 존재
+    return !!user;
   }
 
   async updateUser(id: string, dto: UpdateUserDto) {
     const user = await this.userModel.findOne({ id });
     if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
 
-    const valid = await bcrypt.compare(dto.currentPw, user.password);
-    if (!valid) throw new UnauthorizedException('현재 비밀번호가 일치하지 않습니다.');
+    // 닉네임만 수정하는 경우: 비밀번호 검증 생략
+    const isNicknameOnly = dto.nickname && !dto.newPw && !dto.currentPw;
+    if (!isNicknameOnly) {
+      // 비밀번호 변경 로직
+      if (!dto.currentPw) {
+        throw new BadRequestException('현재 비밀번호를 입력해주세요.');
+      }
 
-    if (dto.newPw) user.password = await bcrypt.hash(dto.newPw, 10);
+      const valid = await bcrypt.compare(dto.currentPw, user.password);
+      if (!valid) throw new UnauthorizedException('현재 비밀번호가 일치하지 않습니다.');
+
+      if (dto.newPw) {
+        user.password = await bcrypt.hash(dto.newPw, 10);
+      }
+    }
+
     if (dto.nickname) user.nickname = dto.nickname;
-
     await user.save();
-    return { id: user.id, nickname: user.nickname };
+
+    return user;
   }
-
-
 }

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -43,6 +43,12 @@ export class AuthService {
     const payload = { sub: user._id, id: user.id };
     const accessToken = this.jwtService.sign(payload);
 
-    return { accessToken, user }; // ✅ 유저 정보도 함께 반환
+    return { accessToken, user }; // 유저 정보도 함께 반환
   }
+
+  async checkId(id: string): Promise<boolean> {
+    const user = await this.userModel.findOne({ id });
+    return !!user; // true면 이미 존재
+  }
+
 }

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -1,31 +1,48 @@
-// src/auth/auth.service.ts
-import { Injectable, ConflictException } from '@nestjs/common';
+import { Injectable, ConflictException, UnauthorizedException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
 import { User, UserDocument } from './schemas/user.schema';
 import { SignupRequestDto } from './dto/signup-request.dto';
+import { LoginRequestDto } from './dto/login-request.dto';
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+    private readonly jwtService: JwtService,
   ) {}
 
   async signup(dto: SignupRequestDto): Promise<UserDocument> {
-    const { email, password, nickname } = dto;
+    const { id, password, nickname } = dto;
 
-    const exists = await this.userModel.findOne({ email });
-    if (exists) throw new ConflictException('이미 가입된 이메일입니다.');
+    const exists = await this.userModel.findOne({ id });
+    if (exists) throw new ConflictException('이미 존재하는 아이디입니다.');
 
     const hashed = await bcrypt.hash(password, 10);
 
     const user = await this.userModel.create({
-      email,
+      id,
       password: hashed,
       nickname,
     });
 
-    return user; // UserDocument
+    return user;
+  }
+
+  async login(dto: LoginRequestDto): Promise<{ accessToken: string; user: UserDocument }> {
+    const { id, password } = dto;
+
+    const user = await this.userModel.findOne({ id });
+    if (!user) throw new UnauthorizedException('존재하지 않는 아이디입니다.');
+
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+    if (!isPasswordValid) throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
+
+    const payload = { sub: user._id, id: user.id };
+    const accessToken = this.jwtService.sign(payload);
+
+    return { accessToken, user }; // ✅ 유저 정보도 함께 반환
   }
 }

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -57,25 +57,25 @@ export class AuthService {
     const user = await this.userModel.findOne({ id });
     if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
 
-    // 닉네임만 수정하는 경우: 비밀번호 검증 생략
     const isNicknameOnly = dto.nickname && !dto.newPw && !dto.currentPw;
     if (!isNicknameOnly) {
-      // 비밀번호 변경 로직
-      if (!dto.currentPw) {
-        throw new BadRequestException('현재 비밀번호를 입력해주세요.');
-      }
+      if (!dto.currentPw) throw new BadRequestException('현재 비밀번호를 입력해주세요.');
 
       const valid = await bcrypt.compare(dto.currentPw, user.password);
       if (!valid) throw new UnauthorizedException('현재 비밀번호가 일치하지 않습니다.');
 
-      if (dto.newPw) {
-        user.password = await bcrypt.hash(dto.newPw, 10);
-      }
+      if (dto.newPw) user.password = await bcrypt.hash(dto.newPw, 10);
     }
 
     if (dto.nickname) user.nickname = dto.nickname;
     await user.save();
 
     return user;
+  }
+
+  async deleteUser(id: string) {
+    const user = await this.userModel.findOneAndDelete({ id });
+    if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    return true;
   }
 }

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -33,7 +33,7 @@ export class AuthService {
     return user;
   }
 
-  async login(dto: LoginRequestDto): Promise<{ accessToken: string; user: UserDocument }> {
+  async login(dto: LoginRequestDto): Promise<{ accessToken: string; refreshToken: string; user: UserDocument }> {
     const { id, password } = dto;
 
     const user = await this.userModel.findOne({ id });
@@ -43,9 +43,35 @@ export class AuthService {
     if (!isPasswordValid) throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
 
     const payload = { sub: user._id, id: user.id };
-    const accessToken = this.jwtService.sign(payload);
+    const accessToken = this.jwtService.sign(payload, { expiresIn: '1h' });
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '14d' });
 
-    return { accessToken, user };
+    //bcrypt로 해싱 후 DB 저장
+    const hashedRefresh = await bcrypt.hash(refreshToken, 10);
+    user.refreshToken = hashedRefresh;
+    await user.save();
+    
+  
+    return { accessToken, refreshToken, user };
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<string> {
+    try {
+      // 토큰 유효성 검증
+      const payload = this.jwtService.verify(refreshToken);
+      const user = await this.userModel.findById(payload.sub);
+      if (!user || !user.refreshToken) throw new UnauthorizedException('유효하지 않은 사용자입니다.');
+
+      // DB의 해시된 refreshToken과 비교
+      const isValid = await bcrypt.compare(refreshToken, user.refreshToken);
+      if (!isValid) throw new UnauthorizedException('리프레시 토큰이 일치하지 않습니다.');
+
+      // 새 Access Token 발급
+      const newAccess = this.jwtService.sign({ sub: user._id, id: user.id }, { expiresIn: '1h' });
+      return newAccess;
+    } catch (err) {
+      throw new UnauthorizedException('리프레시 토큰이 만료되었거나 유효하지 않습니다.');
+    }
   }
 
   async checkId(id: string): Promise<boolean> {

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -5,6 +5,8 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { StringValue } from 'ms';
 import { User, UserDocument } from './schemas/user.schema';
 import { SignupRequestDto } from './dto/signup-request.dto';
 import { LoginRequestDto } from './dto/login-request.dto';
@@ -15,6 +17,7 @@ export class AuthService {
   constructor(
     @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
     private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
   ) {}
 
   async signup(dto: SignupRequestDto): Promise<UserDocument> {
@@ -43,8 +46,17 @@ export class AuthService {
     if (!isPasswordValid) throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
 
     const payload = { sub: user._id, id: user.id };
-    const accessToken = this.jwtService.sign(payload, { expiresIn: '1h' });
-    const refreshToken = this.jwtService.sign(payload, { expiresIn: '14d' });
+    const accessExpiresIn = (this.configService.get<string>('JWT_EXPIRES_IN') || '1h') as StringValue;
+    const refreshExpiresIn = (this.configService.get<string>('JWT_REFRESH_EXPIRES_IN') || '14d') as StringValue;
+
+    const accessToken = this.jwtService.sign(payload, {
+      secret: this.configService.get<string>('JWT_ACCESS_SECRET') || 'default_access_secret',
+      expiresIn: accessExpiresIn,
+    });
+    const refreshToken = this.jwtService.sign(payload, {
+      secret: this.configService.get<string>('JWT_REFRESH_SECRET') || 'default_refresh_secret',
+      expiresIn: refreshExpiresIn,
+    });
 
     //bcrypt로 해싱 후 DB 저장
     const hashedRefresh = await bcrypt.hash(refreshToken, 10);
@@ -58,7 +70,9 @@ export class AuthService {
   async refreshAccessToken(refreshToken: string): Promise<string> {
     try {
       // 토큰 유효성 검증
-      const payload = this.jwtService.verify(refreshToken);
+      const payload = this.jwtService.verify(refreshToken, {
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET') || 'default_refresh_secret',
+      });
       const user = await this.userModel.findById(payload.sub);
       if (!user || !user.refreshToken) throw new UnauthorizedException('유효하지 않은 사용자입니다.');
 
@@ -67,7 +81,14 @@ export class AuthService {
       if (!isValid) throw new UnauthorizedException('리프레시 토큰이 일치하지 않습니다.');
 
       // 새 Access Token 발급
-      const newAccess = this.jwtService.sign({ sub: user._id, id: user.id }, { expiresIn: '1h' });
+      const accessExpiresIn = (this.configService.get<string>('JWT_EXPIRES_IN') || '1h') as StringValue;
+      const newAccess = this.jwtService.sign(
+        { sub: user._id, id: user.id },
+        {
+          secret: this.configService.get<string>('JWT_ACCESS_SECRET') || 'default_access_secret',
+          expiresIn: accessExpiresIn,
+        },
+      );
       return newAccess;
     } catch (err) {
       throw new UnauthorizedException('리프레시 토큰이 만료되었거나 유효하지 않습니다.');

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -51,4 +51,19 @@ export class AuthService {
     return !!user; // true면 이미 존재
   }
 
+  async updateUser(id: string, dto: UpdateUserDto) {
+    const user = await this.userModel.findOne({ id });
+    if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
+
+    const valid = await bcrypt.compare(dto.currentPw, user.password);
+    if (!valid) throw new UnauthorizedException('현재 비밀번호가 일치하지 않습니다.');
+
+    if (dto.newPw) user.password = await bcrypt.hash(dto.newPw, 10);
+    if (dto.nickname) user.nickname = dto.nickname;
+
+    await user.save();
+    return { id: user.id, nickname: user.nickname };
+  }
+
+
 }

--- a/moba-backend/backend/src/auth/auth.service.ts
+++ b/moba-backend/backend/src/auth/auth.service.ts
@@ -125,4 +125,11 @@ export class AuthService {
     if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
     return true;
   }
+
+  async logout(userId: string): Promise<void> {
+    const user = await this.userModel.findOne({ id: userId });
+    if (!user) throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    user.refreshToken = undefined;
+    await user.save();
+  }
 }

--- a/moba-backend/backend/src/auth/dto/login-request.dto.ts
+++ b/moba-backend/backend/src/auth/dto/login-request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+export class LoginRequestDto {
+  @ApiProperty({ example: 'seongmin123', description: '로그인 아이디' })
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({ example: '12345678', description: '비밀번호' })
+  @IsNotEmpty()
+  password: string;
+}

--- a/moba-backend/backend/src/auth/dto/login-response.dto.ts
+++ b/moba-backend/backend/src/auth/dto/login-response.dto.ts
@@ -1,8 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class LoginResponseDto {
   @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', description: 'JWT 액세스 토큰' })
   accessToken: string;
+
+  @ApiPropertyOptional({ example: '(쿠키에 설정됨)', description: 'JWT 리프레시 토큰 (HttpOnly 쿠키로 전달)' })
+  refreshToken?: string;
 
   @ApiProperty({ example: 'seongmin123', description: '로그인 아이디' })
   id: string;

--- a/moba-backend/backend/src/auth/dto/login-response.dto.ts
+++ b/moba-backend/backend/src/auth/dto/login-response.dto.ts
@@ -1,15 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UserResponseDto {
-  @ApiProperty({ example: '66e9488ad52f4b7a...', description: 'MongoDB 사용자 ID' })
-  _id: string;
+export class LoginResponseDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', description: 'JWT 액세스 토큰' })
+  accessToken: string;
 
   @ApiProperty({ example: 'seongmin123', description: '로그인 아이디' })
   id: string;
 
   @ApiProperty({ example: '홍길동', description: '닉네임' })
   nickname: string;
-
-  @ApiProperty({ example: '2025-10-15T12:34:56Z', description: '가입일' })
-  createdAt: Date;
 }

--- a/moba-backend/backend/src/auth/dto/signup-request.dto.ts
+++ b/moba-backend/backend/src/auth/dto/signup-request.dto.ts
@@ -1,11 +1,10 @@
-// src/auth/dto/signup-request.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { IsNotEmpty, MinLength } from 'class-validator';
 
 export class SignupRequestDto {
-  @ApiProperty({ example: 'test@example.com', description: '회원 이메일' })
-  @IsEmail()
-  email: string;
+  @ApiProperty({ example: 'seongmin123', description: '로그인 아이디' })
+  @IsNotEmpty()
+  id: string;
 
   @ApiProperty({ example: '12345678', description: '비밀번호 (최소 8자)' })
   @IsNotEmpty()

--- a/moba-backend/backend/src/auth/dto/update-user.dto.ts
+++ b/moba-backend/backend/src/auth/dto/update-user.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, MinLength, IsNotEmpty } from 'class-validator';
+
+export class UpdateUserDto {
+  @ApiProperty({ example: '새로운 닉네임', required: false })
+  @IsOptional() //선택
+  nickname?: string;
+
+  @ApiProperty({ example: '현재 비밀번호', required: true })
+  @IsNotEmpty()
+  currentPw: string;
+
+  @ApiProperty({ example: '새 비밀번호', required: false })
+  @IsOptional()
+  @MinLength(8)
+  newPw?: string;
+}

--- a/moba-backend/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/moba-backend/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/moba-backend/backend/src/auth/schemas/user.schema.ts
+++ b/moba-backend/backend/src/auth/schemas/user.schema.ts
@@ -1,4 +1,3 @@
-// src/auth/schemas/user.schema.ts
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Types } from 'mongoose';
 
@@ -7,7 +6,7 @@ export type UserDocument = HydratedDocument<User>;
 @Schema({ timestamps: true })
 export class User {
   @Prop({ required: true, unique: true })
-  email: string;
+  id: string;
 
   @Prop({ required: true })
   password: string;

--- a/moba-backend/backend/src/auth/schemas/user.schema.ts
+++ b/moba-backend/backend/src/auth/schemas/user.schema.ts
@@ -14,6 +14,9 @@ export class User {
   @Prop({ required: true })
   nickname: string;
 
+  @Prop({ required:false })
+  refreshToken?: string;
+
   //  TS 타입에 명시 (Mongoose가 자동 추가하지만 TS는 몰라서 오류 났던 부분)
   _id?: Types.ObjectId;
   createdAt?: Date;

--- a/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
+++ b/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
@@ -22,7 +22,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: any): Promise<UserDocument> {
     const user = await this.userModel.findById(payload.sub);
     if (!user) {
-      throw new Error('Invalid token: user not found');
+      throw new UnauthorizedException('Invalid token: user not found');
     }
     return user;
   }

--- a/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
+++ b/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
@@ -14,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: configService.get<string>('JWT_SECRET') || 'default_secret',
+      secretOrKey: configService.get<string>('JWT_ACCESS_SECRET') || 'default_access_secret',
     });
   }
 

--- a/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
+++ b/moba-backend/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, UserDocument } from '../schemas/user.schema';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: configService.get<string>('JWT_SECRET') || 'default_secret',
+    });
+  }
+
+  //토큰에서 user_id를 읽어 DB에서 사용자 확인 후 반환
+  async validate(payload: any): Promise<UserDocument> {
+    const user = await this.userModel.findById(payload.sub);
+    if (!user) {
+      throw new Error('Invalid token: user not found');
+    }
+    return user;
+  }
+}

--- a/moba-backend/backend/src/main.ts
+++ b/moba-backend/backend/src/main.ts
@@ -1,11 +1,16 @@
 import { NestFactory } from '@nestjs/core';
+import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.enableCors({ origin: 'http://localhost:3000' });
+  app.use(cookieParser());
+  app.enableCors({
+    origin: 'http://localhost:3000',
+    credentials: true,
+  });
 
   // Swagger 설정
   const config = new DocumentBuilder()

--- a/moba-backend/backend/src/main.ts
+++ b/moba-backend/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
-import * as cookieParser from 'cookie-parser';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const cookieParser = require('cookie-parser');
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
@@ -10,6 +11,9 @@ async function bootstrap() {
   app.enableCors({
     origin: 'http://localhost:3000',
     credentials: true,
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],
+    exposedHeaders: ['Set-Cookie'],
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   });
 
   // Swagger 설정

--- a/moba-backend/backend/src/movies/movies.controller.ts
+++ b/moba-backend/backend/src/movies/movies.controller.ts
@@ -29,11 +29,13 @@ export class MoviesController {
     return this.moviesService.getMovieVideos(id);
   }
 
-  @Get('search/query')
+  @Get('search')
   @ApiOperation({ summary: '영화 검색', description: '검색어를 기준으로 영화 목록을 검색합니다.' })
   @ApiQuery({ name: 'query', example: 'Inception', description: '검색어' })
   @ApiQuery({ name: 'page', required: false, example: 1, description: '페이지 번호 (기본값 1)' })
   searchMovies(@Query('query') query: string, @Query('page') page?: number) {
     return this.moviesService.searchMovies(query, page);
   }
+
+
 }


### PR DESCRIPTION
<h3>PR 제목</h3>
<p><strong>[feat] Auth 고도화 (JWT Access/Refresh + HttpOnly Cookie + CSRF)</strong></p>
<hr>
<h3>📌 개요</h3>
<p>브라우저 환경에 적합한 안전한 인증 체계를 구축했습니다.<br>
Access/Refresh 토큰 분리, Refresh 토큰의 HttpOnly 쿠키 저장,<br>
CSRF 더블 서브밋 방어, 토큰 재발급 및 로그아웃까지 포함합니다.<br>
Swagger 문서와 CORS/쿠키 설정도 함께 정리했습니다.</p>
<hr>
<h3>🔧 주요 변경사항</h3>
<h4>🧱 Auth</h4>
<ul>
<li>
<p>회원가입: <code inline="">bcrypt</code> 해시 저장, 중복 ID 방지</p>
</li>
<li>
<p>로그인: <code inline="">accessToken</code> 본문 반환, <code inline="">refreshToken</code>은 HttpOnly 쿠키로 발급</p>
</li>
<li>
<p>토큰 재발급: <code inline="">/auth/refresh</code>에서 CSRF 검증 후 새 <code inline="">accessToken</code> 발급</p>
</li>
<li>
<p>로그아웃: <code inline="">/auth/logout</code>에서 CSRF 검증 + RefreshToken 쿠키/DB 무효화</p>
</li>
<li>
<p>보호 라우트: <code inline="">JwtAuthGuard</code>로 인증 확인</p>
</li>
</ul>
<h4>🔒 보안</h4>
<ul>
<li>
<p>CSRF 방어: 더블 서브밋 토큰 (<code inline="">X-CSRF-Token</code> 헤더 ↔ <code inline="">csrfToken</code> 쿠키)</p>
</li>
<li>
<p>쿠키 정책: <code inline="">HttpOnly + Secure + SameSite=Lax</code> (개발/운영 환경 분기 권장)</p>
</li>
</ul>
<h4>⚙️ 인프라</h4>
<ul>
<li>
<p>CORS: <code inline="">credentials</code> 허용, <code inline="">X-CSRF-Token</code> 허용 헤더 추가, <code inline="">Set-Cookie</code> 노출</p>
</li>
<li>
<p><code inline="">cookie-parser</code> 적용</p>
</li>
<li>
<p>환경변수 추가:</p>
<ul>
<li>
<p><code inline="">JWT_ACCESS_SECRET</code>, <code inline="">JWT_REFRESH_SECRET</code></p>
</li>
<li>
<p><code inline="">JWT_EXPIRES_IN</code>, <code inline="">JWT_REFRESH_EXPIRES_IN</code></p>
</li>
</ul>
</li>
</ul>
<h4>🧾 문서화</h4>
<ul>
<li>
<p>Swagger에 Auth 엔드포인트 문서 정리 및 설명 추가</p>
</li>
</ul>
<hr>
<h3>🔗 변경된 엔드포인트</h3>

Method | Endpoint | 설명
-- | -- | --
🟢 POST | /auth/signup | 회원가입
🟢 POST | /auth/login | 로그인 (본문: accessToken, 쿠키: refreshToken, csrfToken)
🟢 POST | /auth/refresh | Access Token 재발급 (헤더: X-CSRF-Token 필요)
🟢 POST | /auth/logout | 로그아웃 (헤더: X-CSRF-Token 필요)
🔵 GET | /auth/protected | JWT 인증 확인
🟢 POST | /auth/check-id | 아이디 중복 확인
🟠 PUT | /auth/update | 회원정보 수정
🔴 DELETE | /auth/delete | 회원 탈퇴


<hr>
<h3>🧪 테스트 방법</h3>
<h4>1️⃣ 회원가입</h4>
<pre><code>POST /auth/signup
{
  "id": "user1",
  "password": "12345678",
  "nickname": "홍길동"
}
→ 201 Created, 비밀번호 해시 저장 확인
</code></pre>
<h4>2️⃣ 로그인</h4>
<pre><code>POST /auth/login
{
  "id": "user1",
  "password": "12345678"
}
→ 본문: accessToken
→ 헤더: Set-Cookie (refreshToken=HttpOnly, csrfToken)
</code></pre>
<ul>
<li>
<p>이후 요청 시 <code inline="">withCredentials: true</code> 설정 필요</p>
</li>
</ul>
<h4>3️⃣ 토큰 재발급</h4>
<pre><code>POST /auth/refresh
헤더: X-CSRF-Token: &lt;csrfToken 쿠키값&gt;
쿠키 포함 (credentials:true)
→ 새 accessToken 반환
</code></pre>
<h4>4️⃣ 보호 라우트</h4>
<pre><code>GET /auth/protected
Authorization: Bearer &lt;accessToken&gt;
→ 200 OK
</code></pre>
<h4>5️⃣ 로그아웃</h4>
<pre><code>POST /auth/logout
헤더: X-CSRF-Token: &lt;csrfToken&gt;
→ refreshToken/csrfToken 쿠키 삭제 + DB refreshToken 제거
→ 이후 /auth/refresh 요청 시 401
</code></pre>
<hr>
<h3>⚙️ 환경 변수</h3>
<pre><code class="language-bash">PORT=4000
MONGO_URI=&lt;MongoDB_URI&gt;

JWT_ACCESS_SECRET=...
JWT_REFRESH_SECRET=...
JWT_EXPIRES_IN=1h
JWT_REFRESH_EXPIRES_IN=14d
</code></pre>
<hr>
<h3>💻 프론트 연동 주의사항</h3>
<ul>
<li>
<p>모든 요청에 <code inline="">credentials</code> 포함</p>
<ul>
<li>
<p>fetch → <code inline="">credentials: 'include'</code></p>
</li>
<li>
<p>Axios → <code inline="">withCredentials: true</code></p>
</li>
</ul>
</li>
<li>
<p><code inline="">/auth/refresh</code>, <code inline="">/auth/logout</code> 호출 시</p>
<ul>
<li>
<p>헤더 <code inline="">X-CSRF-Token</code>에 <code inline="">csrfToken</code> 쿠키값 포함</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>✅ 체크리스트</h3>
<ul class="contains-task-list">
<li class="task-list-item">
<p><input type="checkbox" disabled=""> Swagger에서 signup/login/refresh/logout/protected 정상 동작</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" disabled=""> 비밀번호 해시 저장 및 ID 중복 방지 확인</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" disabled=""> RefreshToken HttpOnly 쿠키 저장 확인</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" disabled=""> CSRF 검증 실패 시 401 반환 확인</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" disabled=""> <code inline="">.env.example</code> / README 업데이트</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" disabled=""> 보안 옵션(secure/sameSite) 환경별 분기 검토</p>
</li>
</ul>
<hr>
<h3>🖼 스크린샷 / 데모 (선택)</h3>
<ul>
<li>
<p>Swagger 호출 캡처</p>
</li>
<p><img width="908" height="612" alt="image" src="https://github.com/user-attachments/assets/ab69f5f1-8c16-401c-85cb-f6efd9c449d5" /></p>

</ul>
<hr>
<h3>🧩 기타</h3>
<ul>
<li>
<p>추후 개선 예정:</p>
<ul>
<li>
<p>리프레시 토큰 로테이션</p>
</li>
<li>
<p>Rate Limiting</p>
</li>
<li>
<p>Helmet 보안 헤더 적용</p>
</li>
<li>
<p>계정 잠금 정책</p>
</li>
</ul>
</li>
</ul>
<hr>
