### PR TITLE
[Feat] 영화 감상문 게시판 및 댓글 시스템 구현 (#10)

### DIFF
--- a/moba-backend/backend/src/app.module.ts
+++ b/moba-backend/backend/src/app.module.ts
@@ -5,6 +5,8 @@ import { MoviesModule } from './movies/movies.module';
 import { BookmarksModule } from './bookmarks/bookmarks.module';
 import { AuthModule } from './auth/auth.module';
 import { ReviewsModule } from './reviews/reviews.module';
+import { PostsModule } from './posts/posts.module';
+import { CommentsModule } from './comments/comments.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { ReviewsModule } from './reviews/reviews.module';
     BookmarksModule,
     AuthModule,
     ReviewsModule,
+    PostsModule,
+    CommentsModule,
   ],
 })
 export class AppModule {}

--- a/moba-backend/backend/src/comments/comments.controller.ts
+++ b/moba-backend/backend/src/comments/comments.controller.ts
@@ -1,0 +1,103 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { CommentResponseDto } from './dto/comment-response.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('Comments')
+@Controller('comments')
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '댓글/대댓글 작성' })
+  @ApiResponse({
+    status: 201,
+    description: '댓글이 성공적으로 작성되었습니다.',
+    type: CommentResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 요청입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 404, description: '게시물 또는 부모 댓글을 찾을 수 없습니다.' })
+  async createComment(@Req() req, @Body() createCommentDto: CreateCommentDto) {
+    return this.commentsService.createComment(
+      req.user._id.toString(),
+      createCommentDto,
+    );
+  }
+
+  @Get('post/:postId')
+  @ApiOperation({ summary: '게시물의 댓글 목록 조회 (대댓글 포함)' })
+  @ApiParam({ name: 'postId', description: '게시물 ID' })
+  @ApiResponse({
+    status: 200,
+    description: '댓글 목록이 성공적으로 조회되었습니다.',
+    type: [CommentResponseDto],
+  })
+  @ApiResponse({ status: 400, description: '잘못된 게시물 ID입니다.' })
+  @ApiResponse({ status: 404, description: '게시물을 찾을 수 없습니다.' })
+  async getCommentsByPost(@Param('postId') postId: string) {
+    return this.commentsService.getCommentsByPost(postId);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '댓글 수정' })
+  @ApiParam({ name: 'id', description: '댓글 ID' })
+  @ApiResponse({
+    status: 200,
+    description: '댓글이 성공적으로 수정되었습니다.',
+    type: CommentResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 댓글 ID입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 403, description: '자신의 댓글만 수정할 수 있습니다.' })
+  @ApiResponse({ status: 404, description: '댓글을 찾을 수 없습니다.' })
+  async updateComment(
+    @Param('id') id: string,
+    @Req() req,
+    @Body() updateCommentDto: UpdateCommentDto,
+  ) {
+    return this.commentsService.updateComment(
+      id,
+      req.user._id.toString(),
+      updateCommentDto,
+    );
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '댓글 삭제 (대댓글도 함께 삭제)' })
+  @ApiParam({ name: 'id', description: '댓글 ID' })
+  @ApiResponse({ status: 200, description: '댓글이 성공적으로 삭제되었습니다.' })
+  @ApiResponse({ status: 400, description: '잘못된 댓글 ID입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 403, description: '자신의 댓글만 삭제할 수 있습니다.' })
+  @ApiResponse({ status: 404, description: '댓글을 찾을 수 없습니다.' })
+  async deleteComment(@Param('id') id: string, @Req() req) {
+    await this.commentsService.deleteComment(id, req.user._id.toString());
+    return { message: 'Comment deleted successfully' };
+  }
+}

--- a/moba-backend/backend/src/comments/comments.controller.ts
+++ b/moba-backend/backend/src/comments/comments.controller.ts
@@ -22,7 +22,7 @@ import { UpdateCommentDto } from './dto/update-comment.dto';
 import { CommentResponseDto } from './dto/comment-response.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-@ApiTags('Comments')
+@ApiTags('영화 감상문 댓글 (Comments)')
 @Controller('comments')
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}

--- a/moba-backend/backend/src/comments/comments.module.ts
+++ b/moba-backend/backend/src/comments/comments.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { CommentsController } from './comments.controller';
+import { CommentsService } from './comments.service';
+import { Comment, CommentSchema } from './schemas/comment.schema';
+import { PostsModule } from '../posts/posts.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Comment.name, schema: CommentSchema }]),
+    PostsModule,
+  ],
+  controllers: [CommentsController],
+  providers: [CommentsService],
+  exports: [CommentsService],
+})
+export class CommentsModule {}

--- a/moba-backend/backend/src/comments/comments.service.ts
+++ b/moba-backend/backend/src/comments/comments.service.ts
@@ -1,0 +1,147 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Comment, CommentDocument } from './schemas/comment.schema';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { PostsService } from '../posts/posts.service';
+
+@Injectable()
+export class CommentsService {
+  constructor(
+    @InjectModel(Comment.name) private commentModel: Model<CommentDocument>,
+    private postsService: PostsService,
+  ) {}
+
+  async createComment(
+    userId: string,
+    createCommentDto: CreateCommentDto,
+  ): Promise<CommentDocument> {
+    const { postId, parentCommentId } = createCommentDto;
+
+    // 게시물 존재 확인
+    await this.postsService.getPostById(postId);
+
+    // 부모 댓글 존재 확인 (대댓글인 경우)
+    if (parentCommentId) {
+      const parentComment = await this.commentModel.findById(parentCommentId);
+      if (!parentComment) {
+        throw new NotFoundException('Parent comment not found');
+      }
+      // 대댓글의 대댓글은 허용하지 않음
+      if (parentComment.parentCommentId) {
+        throw new BadRequestException('Cannot reply to a reply');
+      }
+    }
+
+    const comment = new this.commentModel({
+      postId: new Types.ObjectId(postId),
+      userId: new Types.ObjectId(userId),
+      content: createCommentDto.content,
+      parentCommentId: parentCommentId
+        ? new Types.ObjectId(parentCommentId)
+        : null,
+    });
+
+    const savedComment = await comment.save();
+
+    // 게시물의 댓글 수 증가 (최상위 댓글만)
+    if (!parentCommentId) {
+      await this.postsService.incrementCommentCount(postId);
+    }
+
+    return savedComment;
+  }
+
+  async getCommentsByPost(postId: string): Promise<CommentDocument[]> {
+    if (!Types.ObjectId.isValid(postId)) {
+      throw new BadRequestException('Invalid post ID');
+    }
+
+    // 게시물 존재 확인
+    await this.postsService.getPostById(postId);
+
+    // 최상위 댓글만 가져오기 (대댓글 제외)
+    const comments = await this.commentModel
+      .find({
+        postId: new Types.ObjectId(postId),
+        parentCommentId: null,
+      })
+      .sort({ createdAt: 1 })
+      .populate('userId', 'id nickname')
+      .exec();
+
+    // 각 댓글의 대댓글 가져오기
+    const commentsWithReplies = await Promise.all(
+      comments.map(async (comment) => {
+        const replies = await this.commentModel
+          .find({ parentCommentId: comment._id })
+          .sort({ createdAt: 1 })
+          .populate('userId', 'id nickname')
+          .exec();
+
+        return {
+          ...comment.toObject(),
+          replies,
+        };
+      }),
+    );
+
+    return commentsWithReplies as any;
+  }
+
+  async updateComment(
+    commentId: string,
+    userId: string,
+    updateCommentDto: UpdateCommentDto,
+  ): Promise<CommentDocument> {
+    if (!Types.ObjectId.isValid(commentId)) {
+      throw new BadRequestException('Invalid comment ID');
+    }
+
+    const comment = await this.commentModel.findById(commentId);
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+
+    if (comment.userId.toString() !== userId) {
+      throw new ForbiddenException('You can only update your own comments');
+    }
+
+    comment.content = updateCommentDto.content;
+    return comment.save();
+  }
+
+  async deleteComment(commentId: string, userId: string): Promise<void> {
+    if (!Types.ObjectId.isValid(commentId)) {
+      throw new BadRequestException('Invalid comment ID');
+    }
+
+    const comment = await this.commentModel.findById(commentId);
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+
+    if (comment.userId.toString() !== userId) {
+      throw new ForbiddenException('You can only delete your own comments');
+    }
+
+    // 대댓글도 함께 삭제
+    if (!comment.parentCommentId) {
+      await this.commentModel.deleteMany({ parentCommentId: comment._id });
+      // 게시물의 댓글 수 감소
+      await this.postsService.decrementCommentCount(
+        comment.postId.toString(),
+      );
+    }
+
+    await this.commentModel.findByIdAndDelete(commentId);
+  }
+}

--- a/moba-backend/backend/src/comments/dto/comment-response.dto.ts
+++ b/moba-backend/backend/src/comments/dto/comment-response.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CommentAuthorDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '507f1f77bcf86cd799439011',
+  })
+  _id: string;
+
+  @ApiProperty({
+    description: '사용자명',
+    example: 'moviefan123',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '닉네임',
+    example: '영화광',
+  })
+  nickname: string;
+}
+
+export class CommentResponseDto {
+  @ApiProperty({
+    description: '댓글 ID',
+    example: '507f1f77bcf86cd799439011',
+  })
+  _id: string;
+
+  @ApiProperty({
+    description: '게시물 ID',
+    example: '507f1f77bcf86cd799439012',
+  })
+  postId: string;
+
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '정말 공감되는 리뷰네요!',
+  })
+  content: string;
+
+  @ApiProperty({
+    description: '작성자 정보',
+    type: CommentAuthorDto,
+  })
+  author: CommentAuthorDto;
+
+  @ApiProperty({
+    description: '부모 댓글 ID (대댓글인 경우)',
+    example: '507f1f77bcf86cd799439013',
+    required: false,
+  })
+  parentCommentId?: string;
+
+  @ApiProperty({
+    description: '대댓글 목록',
+    type: [CommentResponseDto],
+    required: false,
+  })
+  replies?: CommentResponseDto[];
+
+  @ApiProperty({
+    description: '생성 일시',
+    example: '2025-01-15T10:30:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '수정 일시',
+    example: '2025-01-15T12:45:00.000Z',
+  })
+  updatedAt: Date;
+}

--- a/moba-backend/backend/src/comments/dto/create-comment.dto.ts
+++ b/moba-backend/backend/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsMongoId, IsOptional, MinLength, MaxLength } from 'class-validator';
+
+export class CreateCommentDto {
+  @ApiProperty({
+    description: '게시물 ID',
+    example: '507f1f77bcf86cd799439011',
+  })
+  @IsMongoId()
+  postId: string;
+
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '정말 공감되는 리뷰네요! 저도 이 영화를 정말 좋아합니다.',
+    minLength: 1,
+    maxLength: 500,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  content: string;
+
+  @ApiProperty({
+    description: '부모 댓글 ID (대댓글인 경우)',
+    example: '507f1f77bcf86cd799439012',
+    required: false,
+  })
+  @IsMongoId()
+  @IsOptional()
+  parentCommentId?: string;
+}

--- a/moba-backend/backend/src/comments/dto/update-comment.dto.ts
+++ b/moba-backend/backend/src/comments/dto/update-comment.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength, MaxLength } from 'class-validator';
+
+export class UpdateCommentDto {
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '수정된 댓글 내용입니다.',
+    minLength: 1,
+    maxLength: 500,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  content: string;
+}

--- a/moba-backend/backend/src/comments/schemas/comment.schema.ts
+++ b/moba-backend/backend/src/comments/schemas/comment.schema.ts
@@ -1,0 +1,32 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type CommentDocument = Comment & Document;
+
+@Schema({ timestamps: true })
+export class Comment {
+  @Prop({ type: Types.ObjectId, ref: 'Post', required: true })
+  postId: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  userId: Types.ObjectId;
+
+  @Prop({ required: true, maxlength: 500 })
+  content: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Comment', default: null })
+  parentCommentId?: Types.ObjectId;
+
+  @Prop()
+  createdAt: Date;
+
+  @Prop()
+  updatedAt: Date;
+}
+
+export const CommentSchema = SchemaFactory.createForClass(Comment);
+
+// 인덱스 설정
+CommentSchema.index({ postId: 1, createdAt: 1 }); // 게시물별 댓글 조회 최적화
+CommentSchema.index({ parentCommentId: 1, createdAt: 1 }); // 대댓글 조회 최적화
+CommentSchema.index({ userId: 1 }); // 사용자별 댓글 조회

--- a/moba-backend/backend/src/posts/dto/create-post.dto.ts
+++ b/moba-backend/backend/src/posts/dto/create-post.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNumber, IsOptional, Min, Max, MinLength, MaxLength } from 'class-validator';
+
+export class CreatePostDto {
+  @ApiProperty({
+    description: '게시물 제목',
+    example: '인셉션 - 현실과 꿈의 경계를 넘나드는 걸작',
+    minLength: 1,
+    maxLength: 100,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  title: string;
+
+  @ApiProperty({
+    description: '게시물 본문',
+    example: '크리스토퍼 놀란 감독의 인셉션은 꿈과 현실의 경계를 탐험하는 독창적인 작품입니다. 복잡한 구조에도 불구하고 스토리는 명확하고...',
+    minLength: 1,
+    maxLength: 5000,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(5000)
+  content: string;
+
+  @ApiProperty({
+    description: 'TMDB 영화 ID',
+    example: 27205,
+  })
+  @IsNumber()
+  movieId: number;
+
+  @ApiProperty({
+    description: '영화 제목',
+    example: '인셉션',
+  })
+  @IsString()
+  movieTitle: string;
+
+  @ApiProperty({
+    description: '영화 포스터 이미지 URL',
+    example: '/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  moviePoster?: string;
+
+  @ApiProperty({
+    description: '영화 평점 (1-5점)',
+    example: 5,
+    minimum: 1,
+    maximum: 5,
+  })
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  rating: number;
+}

--- a/moba-backend/backend/src/posts/dto/post-response.dto.ts
+++ b/moba-backend/backend/src/posts/dto/post-response.dto.ts
@@ -1,0 +1,103 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PostAuthorDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '507f1f77bcf86cd799439011',
+  })
+  _id: string;
+
+  @ApiProperty({
+    description: '사용자명',
+    example: 'moviefan123',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '닉네임',
+    example: '영화광',
+  })
+  nickname: string;
+}
+
+export class PostResponseDto {
+  @ApiProperty({
+    description: '게시물 ID',
+    example: '507f1f77bcf86cd799439011',
+  })
+  _id: string;
+
+  @ApiProperty({
+    description: '게시물 제목',
+    example: '인셉션 - 현실과 꿈의 경계를 넘나드는 걸작',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '게시물 본문',
+    example: '크리스토퍼 놀란 감독의 인셉션은 꿈과 현실의 경계를 탐험하는 독창적인 작품입니다...',
+  })
+  content: string;
+
+  @ApiProperty({
+    description: 'TMDB 영화 ID',
+    example: 27205,
+  })
+  movieId: number;
+
+  @ApiProperty({
+    description: '영화 제목',
+    example: '인셉션',
+  })
+  movieTitle: string;
+
+  @ApiProperty({
+    description: '영화 포스터 이미지 URL',
+    example: '/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg',
+    required: false,
+  })
+  moviePoster?: string;
+
+  @ApiProperty({
+    description: '영화 평점 (1-5점)',
+    example: 5,
+  })
+  rating: number;
+
+  @ApiProperty({
+    description: '작성자 정보',
+    type: PostAuthorDto,
+  })
+  author: PostAuthorDto;
+
+  @ApiProperty({
+    description: '좋아요 수',
+    example: 42,
+  })
+  likes: number;
+
+  @ApiProperty({
+    description: '댓글 수',
+    example: 15,
+  })
+  commentCount: number;
+
+  @ApiProperty({
+    description: '현재 사용자의 좋아요 여부',
+    example: true,
+    required: false,
+  })
+  isLiked?: boolean;
+
+  @ApiProperty({
+    description: '생성 일시',
+    example: '2025-01-15T10:30:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '수정 일시',
+    example: '2025-01-15T12:45:00.000Z',
+  })
+  updatedAt: Date;
+}

--- a/moba-backend/backend/src/posts/dto/update-post.dto.ts
+++ b/moba-backend/backend/src/posts/dto/update-post.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNumber, IsOptional, Min, Max, MinLength, MaxLength } from 'class-validator';
+
+export class UpdatePostDto {
+  @ApiProperty({
+    description: '게시물 제목',
+    example: '인셉션 - 현실과 꿈의 경계를 넘나드는 걸작 (수정)',
+    minLength: 1,
+    maxLength: 100,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(1)
+  @MaxLength(100)
+  title?: string;
+
+  @ApiProperty({
+    description: '게시물 본문',
+    example: '다시 보니 더욱 명확해지는 스토리 구조...',
+    minLength: 1,
+    maxLength: 5000,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(1)
+  @MaxLength(5000)
+  content?: string;
+
+  @ApiProperty({
+    description: '영화 평점 (1-5점)',
+    example: 4,
+    minimum: 1,
+    maximum: 5,
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+}

--- a/moba-backend/backend/src/posts/posts.controller.ts
+++ b/moba-backend/backend/src/posts/posts.controller.ts
@@ -26,7 +26,7 @@ import { UpdatePostDto } from './dto/update-post.dto';
 import { PostResponseDto } from './dto/post-response.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-@ApiTags('Posts')
+@ApiTags('영화 감상문 게시판 (Posts)')
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}

--- a/moba-backend/backend/src/posts/posts.controller.ts
+++ b/moba-backend/backend/src/posts/posts.controller.ts
@@ -1,0 +1,148 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Req,
+  UseGuards,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { PostsService } from './posts.service';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+import { PostResponseDto } from './dto/post-response.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('Posts')
+@Controller('posts')
+export class PostsController {
+  constructor(private readonly postsService: PostsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '감상문 작성' })
+  @ApiResponse({
+    status: 201,
+    description: '감상문이 성공적으로 작성되었습니다.',
+    type: PostResponseDto,
+  })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  async createPost(@Req() req, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.createPost(req.user._id.toString(), createPostDto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: '감상문 목록 조회 (페이지네이션)' })
+  @ApiQuery({ name: 'page', required: false, description: '페이지 번호', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, description: '페이지당 항목 수', example: 10 })
+  @ApiResponse({
+    status: 200,
+    description: '감상문 목록이 성공적으로 조회되었습니다.',
+  })
+  async getPosts(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return this.postsService.getPosts(page, limit);
+  }
+
+  @Get('user/:userId')
+  @ApiOperation({ summary: '특정 사용자의 감상문 목록 조회' })
+  @ApiParam({ name: 'userId', description: '사용자 ID' })
+  @ApiQuery({ name: 'page', required: false, description: '페이지 번호', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, description: '페이지당 항목 수', example: 10 })
+  @ApiResponse({
+    status: 200,
+    description: '사용자의 감상문 목록이 성공적으로 조회되었습니다.',
+  })
+  @ApiResponse({ status: 400, description: '잘못된 사용자 ID입니다.' })
+  async getPostsByUser(
+    @Param('userId') userId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return this.postsService.getPostsByUser(userId, page, limit);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '감상문 상세 조회' })
+  @ApiParam({ name: 'id', description: '게시물 ID' })
+  @ApiResponse({
+    status: 200,
+    description: '감상문이 성공적으로 조회되었습니다.',
+    type: PostResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 게시물 ID입니다.' })
+  @ApiResponse({ status: 404, description: '게시물을 찾을 수 없습니다.' })
+  async getPostById(@Param('id') id: string) {
+    return this.postsService.getPostById(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '감상문 수정' })
+  @ApiParam({ name: 'id', description: '게시물 ID' })
+  @ApiResponse({
+    status: 200,
+    description: '감상문이 성공적으로 수정되었습니다.',
+    type: PostResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 게시물 ID입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 403, description: '자신의 게시물만 수정할 수 있습니다.' })
+  @ApiResponse({ status: 404, description: '게시물을 찾을 수 없습니다.' })
+  async updatePost(
+    @Param('id') id: string,
+    @Req() req,
+    @Body() updatePostDto: UpdatePostDto,
+  ) {
+    return this.postsService.updatePost(id, req.user._id.toString(), updatePostDto);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '감상문 삭제' })
+  @ApiParam({ name: 'id', description: '게시물 ID' })
+  @ApiResponse({ status: 200, description: '감상문이 성공적으로 삭제되었습니다.' })
+  @ApiResponse({ status: 400, description: '잘못된 게시물 ID입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 403, description: '자신의 게시물만 삭제할 수 있습니다.' })
+  @ApiResponse({ status: 404, description: '게시물을 찾을 수 없습니다.' })
+  async deletePost(@Param('id') id: string, @Req() req) {
+    await this.postsService.deletePost(id, req.user._id.toString());
+    return { message: 'Post deleted successfully' };
+  }
+
+  @Post(':id/like')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '감상문 좋아요/취소 (토글)' })
+  @ApiParam({ name: 'id', description: '게시물 ID' })
+  @ApiResponse({
+    status: 200,
+    description: '좋아요가 성공적으로 처리되었습니다.',
+    type: PostResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '잘못된 게시물 ID입니다.' })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 404, description: '게시물을 찾을 수 없습니다.' })
+  async likePost(@Param('id') id: string, @Req() req) {
+    return this.postsService.likePost(id, req.user._id.toString());
+  }
+}

--- a/moba-backend/backend/src/posts/posts.module.ts
+++ b/moba-backend/backend/src/posts/posts.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
+import { Post, PostSchema } from './schemas/post.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Post.name, schema: PostSchema }]),
+  ],
+  controllers: [PostsController],
+  providers: [PostsService],
+  exports: [PostsService],
+})
+export class PostsModule {}

--- a/moba-backend/backend/src/posts/posts.service.ts
+++ b/moba-backend/backend/src/posts/posts.service.ts
@@ -1,0 +1,182 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Post, PostDocument } from './schemas/post.schema';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+
+@Injectable()
+export class PostsService {
+  constructor(
+    @InjectModel(Post.name) private postModel: Model<PostDocument>,
+  ) {}
+
+  async createPost(
+    userId: string,
+    createPostDto: CreatePostDto,
+  ): Promise<PostDocument> {
+    const post = new this.postModel({
+      ...createPostDto,
+      userId: new Types.ObjectId(userId),
+    });
+    return post.save();
+  }
+
+  async getPosts(page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+
+    const [posts, total] = await Promise.all([
+      this.postModel
+        .find()
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate('userId', 'id nickname')
+        .exec(),
+      this.postModel.countDocuments(),
+    ]);
+
+    return {
+      posts,
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getPostById(postId: string): Promise<PostDocument> {
+    if (!Types.ObjectId.isValid(postId)) {
+      throw new BadRequestException('Invalid post ID');
+    }
+
+    const post = await this.postModel
+      .findById(postId)
+      .populate('userId', 'id nickname')
+      .exec();
+
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+
+    return post;
+  }
+
+  async getPostsByUser(userId: string, page: number = 1, limit: number = 10) {
+    if (!Types.ObjectId.isValid(userId)) {
+      throw new BadRequestException('Invalid user ID');
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [posts, total] = await Promise.all([
+      this.postModel
+        .find({ userId: new Types.ObjectId(userId) })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate('userId', 'id nickname')
+        .exec(),
+      this.postModel.countDocuments({ userId: new Types.ObjectId(userId) }),
+    ]);
+
+    return {
+      posts,
+      total,
+      page,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async updatePost(
+    postId: string,
+    userId: string,
+    updatePostDto: UpdatePostDto,
+  ): Promise<PostDocument> {
+    if (!Types.ObjectId.isValid(postId)) {
+      throw new BadRequestException('Invalid post ID');
+    }
+
+    const post = await this.postModel.findById(postId);
+
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+
+    if (post.userId.toString() !== userId) {
+      throw new ForbiddenException('You can only update your own posts');
+    }
+
+    Object.assign(post, updatePostDto);
+    return post.save();
+  }
+
+  async deletePost(postId: string, userId: string): Promise<void> {
+    if (!Types.ObjectId.isValid(postId)) {
+      throw new BadRequestException('Invalid post ID');
+    }
+
+    const post = await this.postModel.findById(postId);
+
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+
+    if (post.userId.toString() !== userId) {
+      throw new ForbiddenException('You can only delete your own posts');
+    }
+
+    await this.postModel.findByIdAndDelete(postId);
+  }
+
+  async likePost(postId: string, userId: string): Promise<PostDocument> {
+    if (!Types.ObjectId.isValid(postId)) {
+      throw new BadRequestException('Invalid post ID');
+    }
+
+    const userObjectId = new Types.ObjectId(userId);
+
+    // 좋아요 취소 시도
+    let post = await this.postModel.findOneAndUpdate(
+      { _id: postId, likedBy: userObjectId },
+      {
+        $pull: { likedBy: userObjectId },
+        $inc: { likes: -1 },
+      },
+      { new: true },
+    );
+
+    // 좋아요 취소 성공하면 반환
+    if (post) {
+      return post.populate('userId', 'id nickname');
+    }
+
+    // 좋아요 추가 시도
+    post = await this.postModel.findOneAndUpdate(
+      { _id: postId, likedBy: { $ne: userObjectId } },
+      {
+        $push: { likedBy: userObjectId },
+        $inc: { likes: 1 },
+      },
+      { new: true },
+    );
+
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+
+    return post.populate('userId', 'id nickname');
+  }
+
+  async incrementCommentCount(postId: string): Promise<void> {
+    await this.postModel.findByIdAndUpdate(postId, { $inc: { commentCount: 1 } });
+  }
+
+  async decrementCommentCount(postId: string): Promise<void> {
+    await this.postModel.findByIdAndUpdate(postId, { $inc: { commentCount: -1 } });
+  }
+}

--- a/moba-backend/backend/src/posts/schemas/post.schema.ts
+++ b/moba-backend/backend/src/posts/schemas/post.schema.ts
@@ -1,0 +1,50 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type PostDocument = Post & Document;
+
+@Schema({ timestamps: true })
+export class Post {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ required: true })
+  content: string;
+
+  @Prop({ required: true })
+  movieId: number;
+
+  @Prop({ required: true })
+  movieTitle: string;
+
+  @Prop()
+  moviePoster?: string;
+
+  @Prop({ required: true, min: 1, max: 5 })
+  rating: number;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  userId: Types.ObjectId;
+
+  @Prop({ default: 0 })
+  likes: number;
+
+  @Prop({ type: [{ type: Types.ObjectId, ref: 'User' }], default: [] })
+  likedBy: Types.ObjectId[];
+
+  @Prop({ default: 0 })
+  commentCount: number;
+
+  @Prop()
+  createdAt: Date;
+
+  @Prop()
+  updatedAt: Date;
+}
+
+export const PostSchema = SchemaFactory.createForClass(Post);
+
+// 인덱스 설정
+PostSchema.index({ userId: 1, createdAt: -1 }); // 사용자별 게시물 조회 최적화
+PostSchema.index({ createdAt: -1 }); // 최신순 정렬 최적화
+PostSchema.index({ movieId: 1 }); // 영화별 게시물 조회 최적화

--- a/moba-backend/backend/src/reviews/reviews.controller.ts
+++ b/moba-backend/backend/src/reviews/reviews.controller.ts
@@ -20,7 +20,7 @@ import { ReviewResponseDto } from './dto/review-response.dto';
 import { ReviewReactionStatusDto } from './dto/review-reaction-status.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-@ApiTags('Reviews')
+@ApiTags('영화 한줄평 (Reviews)')
 @Controller('reviews')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}


### PR DESCRIPTION

  ## 📝 Description

  영화에 대한 긴 형식의 감상문을 작성하고 공유할 수 있는 게시판 기능과 댓글 시스템을 구현했습니다.

  기존의 짧은 한줄평(Reviews)과 차별화하여, 사용자가 영화에 대해 심도 있는 감상을 제목과 본문을 통해 작성하고, 다른 사용자들과 댓글로 소통할 수 있는 커뮤니티 기능을 제공합니다.

  ---

  ## ✨ What's New

  ### 🎬 영화 감상문 게시판 (Posts Module)
  - 영화 선택 및 평점과 함께 긴 형식의 감상문 작성
  - 페이지네이션을 통한 효율적인 목록 조회
  - 특정 사용자의 모든 감상문 조회 기능
  - 작성자 권한 기반 수정/삭제
  - 토글 방식의 좋아요 기능 (동시성 안전)

  ### 💬 댓글 시스템 (Comments Module)
  - 감상문에 댓글 작성
  - 2단계 대댓글 지원 (댓글 → 대댓글)
  - 계층적 구조로 응답하여 프론트엔드 렌더링 최적화
  - 부모 댓글 삭제 시 대댓글 연쇄 삭제
  - 게시물의 댓글 수 자동 관리

  ---

  ## 🔧 Technical Details

  ### Database Schema

  **Post Schema**
  ```typescript
  {
    title: string              // 제목 (1-100자)
    content: string            // 본문 (1-5000자)
    movieId: number            // TMDB 영화 ID
    movieTitle: string         // 영화 제목
    moviePoster?: string       // 포스터 URL
    rating: number             // 평점 (1-5)
    userId: ObjectId           // 작성자
    likes: number              // 좋아요 수
    likedBy: ObjectId[]        // 좋아요한 사용자 목록
    commentCount: number       // 댓글 수 (역정규화)
    timestamps                 // createdAt, updatedAt
  }

  Comment Schema
  {
    postId: ObjectId           // 게시물 ID
    userId: ObjectId           // 작성자
    content: string            // 댓글 내용 (1-500자)
    parentCommentId?: ObjectId // 부모 댓글 ID (대댓글용)
    timestamps                 // createdAt, updatedAt
  }

  API Endpoints

  Posts (/posts)

  - POST /posts - 감상문 작성 (인증 필요)
  - GET /posts - 감상문 목록 조회 (페이지네이션)
  - GET /posts/:id - 감상문 상세 조회
  - GET /posts/user/:userId - 특정 사용자 감상문 목록
  - PUT /posts/:id - 감상문 수정 (작성자만)
  - DELETE /posts/:id - 감상문 삭제 (작성자만)
  - POST /posts/:id/like - 좋아요 토글

  Comments (/comments)

  - POST /comments - 댓글/대댓글 작성 (인증 필요)
  - GET /comments/post/:postId - 게시물의 댓글 목록 (대댓글 포함)
  - PUT /comments/:id - 댓글 수정 (작성자만)
  - DELETE /comments/:id - 댓글 삭제 (대댓글 자동 삭제)

  ---
  🎯 Key Implementation Highlights

  1. 동시성 안전한 좋아요 처리

  // 원자적 연산으로 race condition 방지
  const post = await this.postModel.findOneAndUpdate(
    { _id: postId, likedBy: userObjectId },
    { $pull: { likedBy: userObjectId }, $inc: { likes: -1 } },
    { new: true }
  );

  2. 계층적 댓글 구조

  - 최상위 댓글 조회 후 각각의 대댓글 포함
  - 프론트엔드에서 바로 렌더링 가능한 중첩 구조 반환
  - 대댓글의 대댓글 방지 (최대 2단계 depth)

  3. 댓글 수 역정규화

  - Post 스키마에 commentCount 필드 저장
  - 댓글 생성/삭제 시 자동 증감
  - 목록 조회 시 별도 집계 연산 불필요

  4. Swagger 태그 개선

  - 영화 감상문 게시판 (Posts) - 긴 글 형식의 감상문
  - 영화 감상문 댓글 (Comments) - 게시판 댓글
  - 영화 한줄평 (Reviews) - 영화 상세의 짧은 리뷰
  - 프론트엔드 개발자가 각 API의 용도를 명확히 구분 가능

  ---
  🔒 Security & Validation

  - 인증: JWT 기반 인증 (작성/수정/삭제/좋아요)
  - 권한: 작성자만 본인 게시물/댓글 수정 및 삭제 가능
  - 입력 검증:
    - 제목: 1-100자
    - 본문: 1-5000자
    - 댓글: 1-500자
    - 평점: 1-5 범위
  - MongoDB ObjectId 검증: 잘못된 ID 형식 차단
  - 동시성 안전: 좋아요 기능 원자적 연산 적용

  ---
  📂 Files Changed

  New Files

  src/posts/
  ├── dto/
  │   ├── create-post.dto.ts
  │   ├── update-post.dto.ts
  │   └── post-response.dto.ts
  ├── schemas/
  │   └── post.schema.ts
  ├── posts.controller.ts
  ├── posts.service.ts
  └── posts.module.ts

  src/comments/
  ├── dto/
  │   ├── create-comment.dto.ts
  │   ├── update-comment.dto.ts
  │   └── comment-response.dto.ts
  ├── schemas/
  │   └── comment.schema.ts
  ├── comments.controller.ts
  ├── comments.service.ts
  └── comments.module.ts

  Modified Files

  - src/app.module.ts - PostsModule, CommentsModule 등록
  - src/posts/posts.controller.ts - Swagger 태그 업데이트
  - src/comments/comments.controller.ts - Swagger 태그 업데이트
  - src/reviews/reviews.controller.ts - Swagger 태그 업데이트

  ---
  🧪 Testing

  - ✅ Swagger UI를 통한 전체 API 테스트 가능
  - ✅ 모든 엔드포인트 문서화 완료
  - ✅ Request/Response 스키마 정의
  - ✅ 예시 데이터 포함

  테스트 방법:
  npm run start:dev
  # http://localhost:4000/api-docs 접속

  ---
  📸 API Documentation Preview

  Swagger UI에서 다음과 같이 그룹화되어 표시됩니다:

  - 영화 감상문 게시판 (Posts) - 7개 엔드포인트
  - 영화 감상문 댓글 (Comments) - 4개 엔드포인트
  - 영화 한줄평 (Reviews) - 10개 엔드포인트 (기존)

  ---
  🔄 Database Indexes

  Posts

  - (userId, createdAt) - 사용자별 게시물 조회 최적화
  - (createdAt) - 최신순 정렬 최적화
  - (movieId) - 영화별 게시물 조회 최적화

  Comments

  - (postId, createdAt) - 게시물별 댓글 조회 최적화
  - (parentCommentId, createdAt) - 대댓글 조회 최적화
  - (userId) - 사용자별 댓글 조회

  ---
  🚀 What's Next (Out of Scope)

  현재 MVP 기능에 집중하여 다음 기능들은 제외되었습니다:
  - ❌ 신고/숨김 기능
  - ❌ 스포일러 보호
  - ❌ 캐싱 (Redis)
  - ❌ 실시간 알림
  - ❌ 게시물 저장 (북마크)
  - ❌ 이미지 업로드

  ---
  ✅ Checklist

  - Post 스키마 생성
  - Comment 스키마 생성
  - DTO 정의 (Create/Update/Response)
  - Posts Service & Controller 구현
  - Comments Service & Controller 구현
  - AppModule에 모듈 등록
  - Swagger 문서화
  - 동시성 안전 좋아요 구현
  - 대댓글 계층 구조 구현
  - 권한 검증 구현
  - MongoDB 인덱스 설정
  - 입력 검증 구현

  ---
  📌 Related Issues

  Closes #[이슈번호]

  ---
  💬 Notes

  - Reviews(한줄평)와 Posts(감상문)는 서로 다른 용도입니다
    - Reviews: 영화 상세 페이지의 짧은 리뷰 (최대 1000자)
    - Posts: 게시판의 긴 감상문 (최대 5000자, 제목 포함)
  - 댓글 시스템은 Posts에만 적용됩니다
  - 모든 API는 Swagger UI에서 테스트 가능합니다