### PR TITLE
feat : 배치형 엔드포인트

### DIFF
--- a/moba-backend/backend/docs/ai_flow_ux.md
+++ b/moba-backend/backend/docs/ai_flow_ux.md
@@ -1,0 +1,166 @@
+# AI 추천 흐름 · UX 시나리오 · API 가이드
+
+본 문서는 프론트에서 영화 추천 UX를 구현하기 위한 전체 흐름, 화면별 시나리오, 요청/응답 형식, 엔드포인트를 정리합니다. 경로 A(콘텐츠 기반)로 동작하며 TF‑IDF를 기본으로, `.env`에 `USE_SBERT=true`일 때 SBERT 임베딩까지 혼합합니다.
+
+## 핵심 개념
+- 로컬 우선: 추천/후보는 로컬 DB(사전 동기화)에서 먼저 가져옵니다.
+- 폴백·자동 동기화: 로컬이 부족하면 TMDB로 즉시 응답하고, 백그라운드로 로컬 DB에 저장·임베딩 처리 후 재조회 시 반영됩니다.
+- 개인화: 사용자가 좋아요/싫어요한 영화들의 벡터 평균(긍정/부정 분리)을 후보와 코사인 유사도로 비교하고, 장르/인기도/평점/최신성까지 재랭킹합니다.
+- 메타: `partial`, `jobId(s)`, `nextRefreshAfter`, `source`로 응답 상태를 전달합니다.
+
+---
+
+## UX 시나리오
+- 온보딩(최초 방문)
+  - 장르 선택 화면 → `POST /v1/profile/genres` 저장
+  - 바로 개인 추천 호출 → `GET /v1/reco/personal?userId=...&size=...`
+    - 로컬 데이터 충분 → 전체 리스트 표시(`partial=false`)
+    - 로컬 부족 → 부분 리스트 우선 표시(`partial=true`), 상단에 "업데이트 중…" 토스트·스피너 노출 → `nextRefreshAfter`(≈5초) 뒤 자동 재조회
+- 홈/피드(재방문)
+  - 앱 진입 즉시 `GET /v1/reco/personal` 호출, 바로 리스트 표시
+  - 카드를 터치해 상세로 진입하거나, 카드의 좋아요/싫어요/보관 등을 수행
+- 후보 그리드(선택 기능)
+  - 장르별 둘러보기 → `GET /v1/reco/candidates?genres=...&page=1&size=20`
+  - 일부만 폴백이면 `partial=true`이므로 동일 UX(토스트·자동 재조회)
+- 상세 화면
+  - 배우/제작진 호출 → `GET /movies/:id/credits`
+  - 프로필 이미지는 `http://image.tmdb.org/t/p/{size}{profile_path}`로 빌드(예: `w185`)
+- 피드백 루프(개인화 강화)
+  - 좋아요/싫어요/클릭/완주 시 `POST /v1/reco/feedback`
+  - 즉시 `GET /v1/reco/personal`을 재호출하여 “바로 반영됨” 체감 제공
+- 빈/예외 케이스
+  - 결과가 비어도 폴백으로 최소한의 리스트가 먼저 표시됨(`partial=true`)
+  - 연속 폴백 시 최대 2~3회 자동 재시도 후, 안내 메시지와 함께 트렌딩/인기 섹션을 대체 컨텐츠로 노출
+
+---
+
+## 호출 순서(권장)
+1) 선호 장르 저장(온보딩)
+- POST `/v1/profile/genres` → `{ userId, favoriteGenres }`
+2) 개인 추천 호출(핵심)
+- GET `/v1/reco/personal?userId=...&size=...`
+- `meta.partial=true`면 `meta.nextRefreshAfter`초 후 자동 재호출(또는 `GET /v1/reco/jobs/:id` 폴링 뒤 재호출)
+3) 후보 그리드(옵션)
+- GET `/v1/reco/candidates?genres=...&page=1&size=20`
+4) 피드백(좋아요/싫어요/클릭/완주)
+- POST `/v1/reco/feedback` → 즉시 `GET /v1/reco/personal` 재호출
+5) 관리자 시드(개발/운영 보조)
+- POST `/v1/admin/sync/discover?genres=28,878,53&pages=2`
+- POST `/v1/admin/sync/movie/:id`
+
+---
+
+## 응답 메타 의미
+- `partial`: true면 TMDB 폴백이 섞인 부분 결과(백그라운드 동기화 중)
+- `jobId`/`jobIds`: 동기화 잡 식별자(선택, 폴링에 사용 가능)
+- `nextRefreshAfter`: n초 뒤 재호출 권장
+- `source`: `local`(로컬만) | `fallback`(TMDB만) | `mixed`(혼합)
+프론트 처리 규칙
+- `partial=false` → 그대로 렌더
+- `partial=true` → 즉시 렌더 + 스피너/토스트 노출 → `nextRefreshAfter` 후 재호출(또는 `reco/jobs/:id` 완료 확인 후 재호출)
+
+---
+
+## 엔드포인트 정리
+### 선호 장르 저장
+- POST `/v1/profile/genres`
+- Body
+```json
+{ "userId": "u_123", "favoriteGenres": [28, 878, 53] }
+```
+- 200
+```json
+{ "userId": "u_123", "favoriteGenres": [28, 878, 53] }
+```
+### 후보(장르 기반)
+- GET `/v1/reco/candidates?genres=28,878,53&page=1&size=20`
+- 200
+```json
+{
+  "items": [
+    { "id": 603, "title": "The Matrix", "genre_ids": [28, 878], "overview": "...", "poster_path": "/...jpg", "popularity": 92.4, "vote_average": 8.7, "release_date": "1999-03-31" }
+  ],
+  "meta": { "source": "local", "partial": false }
+}
+```
+### 개인 추천(핵심)
+- GET `/v1/reco/personal?userId=u_123&size=20`
+- 200
+```json
+{
+  "items": [
+    {
+      "movieId": 603,
+      "title": "The Matrix",
+      "posterPath": "/...jpg",
+      "score": 0.91,
+      "reasons": [
+        "matchedGenres:2",
+        "popularity:92.4",
+        "vote:8.7",
+        "recency:0.85",
+        "tfidf:0.62",
+        "sbert:0.71"
+      ]
+    }
+  ],
+  "meta": { "partial": false, "source": "local" }
+}
+```
+- Notes
+  - `reasons`는 설명가능성 제공(장르/인기/평점/최신성/TF‑IDF/SBERT/neg/explore 등)
+  - `partial=true`면 위의 메타 처리 규칙 적용
+### 피드백(좋아요/싫어요/클릭/완주)
+- POST `/v1/reco/feedback`
+- Body
+```json
+{ "userId": "u_123", "movieId": 603, "label": 1, "source": "like" }
+```
+- label: 1=positive(like/watch), 0=negative(skip)
+- source: `like|click|watch|skip`
+- 200 `{ "ok": true }`
+### 잡 상태(옵션)
+- GET `/v1/reco/jobs/:id`
+- 200 `{ "id": "abc123", "status": "running", "updatedAt": 1730000000000 }`
+- status: `pending|running|completed|failed|not_found`
+### 영화 크레딧(배우/제작진)
+- GET `/movies/:id/credits`
+- 200 (TMDB 원본 필드 유지)
+```json
+{ "id": 550, "cast": [ { "id": 819, "name": "Edward Norton", "character": "...", "order": 0, "profile_path": "/...jpg" } ], "crew": [ { "id": 7467, "name": "David Fincher", "department": "Directing", "job": "Director", "profile_path": "/...jpg" } ] }
+```
+- 500 `{ "error": "Failed to fetch movie credits" }`
+- 이미지 URL: `http://image.tmdb.org/t/p/{size}{profile_path}` (예: `w185`)
+### 관리자(시드/온디맨드 동기화)
+- POST `/v1/admin/sync/discover?genres=28,878,53&pages=2` → `{ "ok": true }`
+- POST `/v1/admin/sync/movie/:id` → `{ "movieId": 603, "title": "The Matrix" }`
+
+---
+
+## 에러/엣지 대응
+- TMDB 실패: 폴백 구간에서 500 발생 시 메시지 토스트 + 다음 재조회 유도
+- 추천 결과 0개: 트렌딩/인기 리스트로 대체 노출(UX 가이드)
+- 이미지 누락: placeholder 처리
+
+---
+
+## SBERT 사용 시
+- 조건: `.env`에 `USE_SBERT=true` + `@xenova/transformers` 설치
+- 동기화 시 SBERT 임베딩 생성·저장 → 추천 시 TF‑IDF + SBERT 코사인 혼합
+- 응답 `reasons`에 `sbert:0.xxx`가 포함되면 SBERT 반영됨
+
+---
+
+## Swagger
+- URL: `http://localhost:${PORT}/api-docs` (기본 4000)
+- 태그: Recommendations, Admin/Ingest, Movies 등
+
+---
+
+## 체크리스트(프론트)
+- [ ] `partial=true` 처리(스피너/토스트 + 자동 재조회/잡 폴링)
+- [ ] `reasons` 일부를 카드에 설명으로 노출(예: "장르 2개 일치 · 평점 8.7")
+- [ ] 피드백 후 즉시 `GET /v1/reco/personal` 재호출
+- [ ] 크레딧 이미지 URL 빌더 적용
+- [ ] 빈 결과/에러 fallback UI 적용
+

--- a/moba-backend/backend/ecosystem.config.js
+++ b/moba-backend/backend/ecosystem.config.js
@@ -5,6 +5,7 @@ module.exports = {
       script: './dist/main.js',
       instances: 1,
       exec_mode: 'cluster',
+      node_args: process.env.NODE_OPTIONS || '--max-old-space-size=3072',
       watch: false,
       max_memory_restart: '1G',
       env: {

--- a/moba-backend/backend/src/common/interceptors/logging.interceptor.ts
+++ b/moba-backend/backend/src/common/interceptors/logging.interceptor.ts
@@ -11,10 +11,35 @@ import { tap } from 'rxjs/operators';
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger('HTTP');
+  private previewBody(value: any, limit = 2048): string {
+    try {
+      if (Array.isArray(value)) return `Array(${value.length})`;
+      if (value && typeof value === 'object') {
+        const keys = Object.keys(value);
+        const cut = keys.slice(0, 20);
+        const summary: Record<string, any> = {} as any;
+        for (const k of cut) {
+          const v = (value as any)[k];
+          if (Array.isArray(v)) summary[k] = `Array(${v.length})`;
+          else if (v && typeof v === 'object') summary[k] = '[Object]';
+          else if (typeof v === 'string') summary[k] = v.length > 200 ? v.slice(0, 200) + '…' : v;
+          else summary[k] = v;
+        }
+        const more = keys.length > cut.length ? `, …+${keys.length - cut.length} keys` : '';
+        const s = JSON.stringify(summary);
+        return s.length > limit ? s.slice(0, limit) + '…' : s + more;
+      }
+      if (typeof value === 'string') return value.length > 200 ? value.slice(0, 200) + '…' : value;
+      return JSON.stringify(value);
+    } catch {
+      return '[unserializable body]';
+    }
+  }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
     const { method, url, body, headers } = request;
+    const contentLength = Number(headers['content-length'] || 0);
     const userAgent = headers['user-agent'] || '';
     const userId = request.user?._id || request.user?.id || 'Anonymous';
 

--- a/moba-backend/backend/src/main.ts
+++ b/moba-backend/backend/src/main.ts
@@ -5,6 +5,8 @@ const cookieParser = require('cookie-parser');
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { json, urlencoded } from 'express';
+import axios from 'axios';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -12,6 +14,18 @@ async function bootstrap() {
   });
 
   const logger = new Logger('Bootstrap');
+
+  // Prevent OOM: limit inbound body size and constrain axios
+  const jsonLimit = process.env.JSON_BODY_LIMIT || '1mb';
+  const urlLimit = process.env.URLENCODED_BODY_LIMIT || '1mb';
+  app.use(json({ limit: jsonLimit }));
+  app.use(urlencoded({ extended: true, limit: urlLimit }));
+
+  axios.defaults.timeout = Number(process.env.AXIOS_TIMEOUT || 7000);
+  // @ts-ignore
+  axios.defaults.maxContentLength = Number(process.env.AXIOS_MAX_CONTENT_LENGTH || 10 * 1024 * 1024);
+  // @ts-ignore
+  axios.defaults.maxBodyLength = Number(process.env.AXIOS_MAX_BODY_LENGTH || 10 * 1024 * 1024);
 
   // 글로벌 로깅 인터셉터
   app.useGlobalInterceptors(new LoggingInterceptor());

--- a/moba-backend/backend/src/reco/dto/commit.dto.ts
+++ b/moba-backend/backend/src/reco/dto/commit.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, IsOptional, IsString, ArrayUnique } from 'class-validator';
+
+export class CommitDto {
+  @ApiProperty({ example: 'user_123' })
+  @IsString()
+  userId!: string;
+
+  @ApiProperty({ type: [Number], required: false })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  favoriteGenres?: number[] = [];
+
+  @ApiProperty({ type: [Number], required: false })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  likes?: number[] = [];
+
+  @ApiProperty({ type: [Number], required: false })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  dislikes?: number[] = [];
+}
+

--- a/moba-backend/backend/src/reco/dto/preview.dto.ts
+++ b/moba-backend/backend/src/reco/dto/preview.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, IsOptional, IsString, ArrayNotEmpty, ArrayUnique } from 'class-validator';
+
+export class PreviewDto {
+  @ApiProperty({ type: [Number], required: false, description: '선호 장르 ID 배열' })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  favoriteGenres?: number[] = [];
+
+  @ApiProperty({ type: [Number], required: false, description: '좋아요한 영화 ID들' })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  likes?: number[] = [];
+
+  @ApiProperty({ type: [Number], required: false, description: '싫어요한 영화 ID들' })
+  @IsArray()
+  @IsInt({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  dislikes?: number[] = [];
+
+  @ApiProperty({ required: false, default: 20 })
+  @IsOptional()
+  @IsInt()
+  size?: number = 20;
+}
+

--- a/moba-backend/backend/src/reco/reco.controller.ts
+++ b/moba-backend/backend/src/reco/reco.controller.ts
@@ -5,6 +5,8 @@ import { ProfileGenresDto } from './dto/profile-genres.dto';
 import { ProfileLikesDto } from './dto/profile-likes.dto';
 import { JobsService } from './jobs.service';
 import { FeedbackDto } from './dto/feedback.dto';
+import { PreviewDto } from './dto/preview.dto';
+import { CommitDto } from './dto/commit.dto';
 
 @ApiTags('Recommendations')
 @Controller('v1')
@@ -60,5 +62,23 @@ export class RecoController {
   @ApiOperation({ summary: '추천 피드백(긍/부정) 저장' })
   async feedback(@Body() dto: FeedbackDto) {
     return this.recoService.addFeedback(dto);
+  }
+
+  @Post('reco/preview')
+  @ApiOperation({ summary: '배치형 개인화 추천 미리보기(저장 없음)' })
+  async preview(@Body() dto: PreviewDto) {
+    const size = Number(dto.size || 20);
+    return this.recoService.previewRecommendations({
+      favoriteGenres: dto.favoriteGenres || [],
+      likes: dto.likes || [],
+      dislikes: dto.dislikes || [],
+      size,
+    });
+  }
+
+  @Post('reco/commit')
+  @ApiOperation({ summary: '선호 장르/좋아요/싫어요 일괄 반영' })
+  async commit(@Body() dto: CommitDto) {
+    return this.recoService.commitPreferences(dto);
   }
 }

--- a/moba-backend/backend/src/reco/reco.service.ts
+++ b/moba-backend/backend/src/reco/reco.service.ts
@@ -62,6 +62,178 @@ export class RecoService {
     return profile;
   }
 
+  // Preview personalized recommendations from transient inputs without persisting
+  async previewRecommendations(args: { favoriteGenres: number[]; likes: number[]; dislikes: number[]; size: number }) {
+    const favoriteGenres = args.favoriteGenres || [];
+    const size = Math.max(1, Math.min(50, args.size || 20));
+
+    // Candidate pool: two pages by genre
+    const [c1, c2] = await Promise.all([
+      this.getCandidates(favoriteGenres, 1, size),
+      this.getCandidates(favoriteGenres, 2, size),
+    ]);
+    const poolMap = new Map<number, TmdbMovie>();
+    ;[...c1.items, ...c2.items].forEach((m) => poolMap.set(m.id, m));
+    const pool = Array.from(poolMap.values());
+
+    // Build transient user vectors from provided likes/dislikes
+    const likedIds = Array.from(new Set(args.likes || []));
+    const dislikedIds = Array.from(new Set(args.dislikes || []));
+    let userVec: { [term: string]: number } | null = null;
+    let userNegVec: { [term: string]: number } | null = null;
+    let userSbert: number[] | null = null;
+    let userNegSbert: number[] | null = null;
+
+    if (likedIds.length) {
+      const liked = await this.vecModel.find({ movieId: { $in: likedIds } }).lean();
+      if (liked.length) {
+        const acc = new Map<string, number>();
+        let countEmb = 0;
+        let dim = 0;
+        for (const mv of liked) {
+          for (const tw of mv.tfidf || []) acc.set(tw.term, (acc.get(tw.term) || 0) + tw.weight);
+          if (mv.sbert && mv.sbert.length) {
+            if (!userSbert) {
+              userSbert = Array(mv.sbert.length).fill(0);
+              dim = mv.sbert.length;
+            }
+            for (let i = 0; i < mv.sbert.length; i++) userSbert[i] += mv.sbert[i] || 0;
+            countEmb++;
+          }
+        }
+        const factor = 1 / liked.length;
+        userVec = {};
+        for (const [t, w] of acc.entries()) userVec[t] = w * factor;
+        if (userSbert && countEmb > 0 && dim > 0) {
+          for (let i = 0; i < dim; i++) userSbert[i] = userSbert[i] / countEmb;
+        }
+      }
+    }
+
+    if (dislikedIds.length) {
+      const negs = await this.vecModel.find({ movieId: { $in: dislikedIds } }).lean();
+      if (negs.length) {
+        const acc = new Map<string, number>();
+        let countEmb = 0;
+        let dim = 0;
+        for (const mv of negs) {
+          for (const tw of mv.tfidf || []) acc.set(tw.term, (acc.get(tw.term) || 0) + tw.weight);
+          if (mv.sbert && mv.sbert.length) {
+            if (!userNegSbert) {
+              userNegSbert = Array(mv.sbert.length).fill(0);
+              dim = mv.sbert.length;
+            }
+            for (let i = 0; i < mv.sbert.length; i++) userNegSbert[i] += mv.sbert[i] || 0;
+            countEmb++;
+          }
+        }
+        const factor = 1 / negs.length;
+        userNegVec = {};
+        for (const [t, w] of acc.entries()) userNegVec[t] = w * factor;
+        if (userNegSbert && countEmb > 0 && dim > 0) {
+          for (let i = 0; i < dim; i++) userNegSbert[i] = userNegSbert[i] / countEmb;
+        }
+      }
+    }
+
+    // Base ranking
+    let ranked = pool
+      .map((m) => {
+        const { score: baseScore, reasons } = this.scoreMovie(m, favoriteGenres);
+        return {
+          movieId: m.id,
+          title: m.title,
+          posterPath: m.poster_path,
+          score: baseScore,
+          reasons,
+        };
+      })
+      .sort((a, b) => b.score - a.score)
+      .slice(0, size);
+
+    // TF-IDF refine if available
+    if (userVec) {
+      const poolIds = ranked.map((r) => r.movieId);
+      const vecs = await this.vecModel.find({ movieId: { $in: poolIds } }).lean();
+      const map = new Map<number, { tfidf: { term: string; weight: number }[] }>();
+      for (const v of vecs) map.set(v.movieId, { tfidf: v.tfidf || [] });
+      const userWeights = Object.entries(userVec).map(([term, weight]) => ({ term, weight }));
+      for (const r of ranked) {
+        const mv = map.get(r.movieId);
+        if (!mv) continue;
+        const cos = cosineFromWeights(userWeights, mv.tfidf);
+        let negCos = 0;
+        if (userNegVec) {
+          const userNegWeights = Object.entries(userNegVec).map(([term, weight]) => ({ term, weight }));
+          negCos = cosineFromWeights(userNegWeights, mv.tfidf);
+        }
+        const wT = Number(process.env.BLEND_TFIDF ?? 0.2);
+        const wB = Number(process.env.BLEND_BASE ?? 0.3);
+        r.score = wT * cos + wB * r.score - 0.3 * negCos;
+        r.reasons = [...r.reasons, `tfidf:${cos.toFixed(3)}`, negCos ? `neg:${negCos.toFixed(3)}` : ''];
+      }
+      ranked.sort((a, b) => b.score - a.score);
+    }
+
+    // SBERT refine if available and enabled
+    if (userSbert) {
+      const poolIds = ranked.map((r) => r.movieId);
+      const vecs = await this.vecModel.find({ movieId: { $in: poolIds } }, { movieId: 1, sbert: 1 }).lean();
+      const mapS = new Map<number, number[]>();
+      for (const v of vecs) mapS.set(v.movieId, (v as any).sbert || []);
+      const wS = Number(process.env.BLEND_SBERT ?? 0.5);
+      for (const r of ranked) {
+        const mvS = mapS.get(r.movieId);
+        if (!mvS?.length) continue;
+        const cosS = cosineVec(userSbert, mvS);
+        let negS = 0;
+        if (userNegSbert?.length) negS = cosineVec(userNegSbert, mvS);
+        r.score = r.score + wS * cosS - 0.2 * negS;
+        r.reasons = [...r.reasons, `sbert:${cosS.toFixed(3)}`, negS ? `sneg:${negS.toFixed(3)}` : ''];
+      }
+      ranked.sort((a, b) => b.score - a.score);
+    }
+
+    const anyPartial = (c1.meta?.partial || c2.meta?.partial) ? true : false;
+    const meta = { partial: anyPartial, source: anyPartial ? 'mixed' : 'local', nextRefreshAfter: anyPartial ? 5 : undefined };
+    return { items: ranked, meta } as any;
+  }
+
+  async commitPreferences(dto: { userId: string; favoriteGenres?: number[]; likes?: number[]; dislikes?: number[] }) {
+    const userId = dto.userId;
+    const fav = dto.favoriteGenres || [];
+    const likes = Array.from(new Set(dto.likes || []));
+    const dislikes = Array.from(new Set(dto.dislikes || []));
+
+    // Upsert profile with batch updates
+    if (fav.length) await this.upsertFavoriteGenres(userId, fav);
+    if (likes.length) await this.profileModel.findOneAndUpdate(
+      { userId },
+      { $addToSet: { likedMovieIds: { $each: likes } } },
+      { upsert: true },
+    );
+    if (dislikes.length) await this.profileModel.findOneAndUpdate(
+      { userId },
+      { $addToSet: { dislikedMovieIds: { $each: dislikes } } },
+      { upsert: true },
+    );
+
+    // Fire-and-forget: ensure vectors exist for liked/disliked movies (limited)
+    const ensureIds = Array.from(new Set([...likes, ...dislikes])).slice(0, 50);
+    if (ensureIds.length) {
+      setTimeout(async () => {
+        const chunks: number[][] = [];
+        const batch = 5; // limit concurrent inflight operations
+        for (let i = 0; i < ensureIds.length; i += batch) chunks.push(ensureIds.slice(i, i + batch));
+        for (const group of chunks) {
+          await Promise.allSettled(group.map((id) => this.ingest.syncMovieById(id)));
+        }
+      }, 0);
+    }
+
+    return { ok: true, userId };
+  }
+
   async getCandidates(genreIds: number[], page = 1, size = 20): Promise<{ items: TmdbMovie[]; meta: any }> {
     // Prefer local DB if available; fallback to TMDB discover and trigger background sync
     const query: any = genreIds.length ? { genres: { $in: genreIds } } : {};


### PR DESCRIPTION
추가한 엔드포인트                                                                                                                      
                                                                                                                                         
  - POST v1/reco/preview                                                                                                                 
      - 본문: { favoriteGenres?: number[], likes?: number[], dislikes?: number[], size?: number=20 }                                     
      - 저장 없이 즉시 개인화 추천 미리보기. TF‑IDF 기반, SBERT 벡터가 DB에 있으면 함께 반영.                                            
      - 후보는 장르 기반 1~2페이지에서 구성, TMDB fallback 시 meta.partial=true로 알려줌.                                                
  - POST v1/reco/commit                                                                                                                  
      - 본문: { userId: string, favoriteGenres?: number[], likes?: number[], dislikes?: number[] }                                       
      - 선호 장르/좋아요/싫어요를 일괄 저장. 저장 직후 좋아요/싫어요 대상 영화들의 벡터가 없으면 백그라운드에서 upsert(동시 5개 제한)로  
  보장.                                                                                                                                  
                                                                                                                                         
  변경 파일                                                                                                                              
                                                                                                                                         
  - src/reco/dto/preview.dto.ts: 배치 미리보기 DTO                                                                                       
  - src/reco/dto/commit.dto.ts: 일괄 커밋 DTO                                                                                            
  - src/reco/reco.controller.ts: reco/preview, reco/commit 라우트 추가                                                                   
  - src/reco/reco.service.ts: previewRecommendations, commitPreferences 구현                                                             
      - preview: 전달받은 likes/dislikes로 사용자 벡터 계산 → 후보에 TF‑IDF/SBERT 코사인 블렌딩 → 정렬                                   
      - commit: 프로필 upsert 후, 벡터 미보유 영화는 setTimeout으로 백그라운드 ingest(동시성 제한)                                       
                                                                                                                                         
  작동 개요                                                                                                                              
                                                                                                                                         
  - 프론트 UX                                                                                                                            
      - 장르/샘플에서 좋아요·싫어요 여러 개를 로컬에 모은 뒤 → 미리보기 1회 호출 → 결과가 괜찮으면 commit 1회 호출                       
      - 클릭마다 서버 호출/벡터 생성 안 하므로 서버 부하↓                                                                                
  - SBERT 고려                                                                                                                           
      - .env에서 USE_SBERT=true인 경우, DB에 sbert 벡터가 존재하면 미리보기에서도 SBERT 코사인을 반영                                    
      - commit 시 벡터 없으면 백그라운드 인덱싱이 SBERT까지 포함(서비스 설정값에 따름)                                                   
                                                                                                                                         
  주의/튜닝 포인트                                                                                                                       
                                                                                                                                         
  - 개인화 체감 강화: SBERT OFF일 땐 TF‑IDF 비중을 올리세요                                                                              
      - .env 예: BLEND_TFIDF=0.6, BLEND_BASE=0.2 (기본은 0.2/0.3)                                                                        
  - 초기 인덱스: 로컬 DB/벡터가 적으면 개인화 효과 약함 → Admin ingest로 초기에 장르별 몇 페이지 동기화 추천                             
  - 백그라운드 부하: commit에서 동시 5개씩 안전하게 ingest. 더 강한 스로틀/디바운스 원하면 알려주세요.                                   
                                                                                                                                         
  다음 단계                                                                                                                              
                                                                                                                                         
  - 빌드/재시작 후 사용:                                                                                                                 
      - 미리보기: POST v1/reco/preview → 리스트 확인                                                                                     
      - 확정: POST v1/reco/commit → 이후 v1/reco/personal로 개인화 결과 조회                     