### PR TITLE
Ai fix

### DIFF
--- a/moba-backend/backend/src/reco/reco.service.ts
+++ b/moba-backend/backend/src/reco/reco.service.ts
@@ -201,11 +201,32 @@ export class RecoService {
       const vecs = await this.vecModel.find({ movieId: { $in: poolIds } }, { movieId: 1, sbert: 1 }).lean();
       const mapS = new Map<number, number[]>();
       for (const v of vecs) mapS.set(v.movieId, (v as any).sbert || []);
+      // On-the-fly for missing candidate vectors (limited)
+      const enableOTF = this.isTrue(process.env.ON_THE_FLY_SBERT || 'true');
+      if (enableOTF) {
+        const limit = Math.max(1, Number(process.env.ON_THE_FLY_LIMIT || 30));
+        let used = 0;
+        for (const r of ranked) {
+          if (mapS.has(r.movieId)) continue;
+          if (used >= limit) break;
+          const src = pool.find((m) => m.id === r.movieId);
+          const text = this.sbertSvc.buildMovieText({ overview: src?.overview || '' });
+          const emb = await this.embedTextOnTheFly(text);
+          if (emb && emb.length) {
+            mapS.set(r.movieId, emb);
+            used++;
+          }
+        }
+      }
       const wS = Number(process.env.BLEND_SBERT ?? 0.5);
+      const minSim = Number(process.env.SBERT_MIN_SIM || 0);
       for (const r of ranked) {
         const mvS = mapS.get(r.movieId);
         if (!mvS?.length) continue;
         const cosS = cosineVec(userSbert, mvS);
+        if (minSim > 0 && cosS < minSim) {
+          continue;
+        }
         let negS = 0;
         if (userNegSbert?.length) negS = cosineVec(userNegSbert, mvS);
         r.score = r.score + wS * cosS - 0.2 * negS;
@@ -631,6 +652,28 @@ export class RecoService {
           for (let i = 0; i < dim; i++) userSbert[i] = userSbert[i] / countEmb;
         }
       }
+      // On-the-fly SBERT if none could be built from stored vectors
+      const enableOTF = this.isTrue(process.env.ON_THE_FLY_SBERT || 'true');
+      if ((!userSbert || !userSbert.length) && enableOTF) {
+        try {
+          const movies = await this.movieModel.find({ movieId: { $in: likedIds } }, { overview: 1, title: 1 }).lean();
+          let otfCount = 0;
+          const limit = Math.max(1, Number(process.env.ON_THE_FLY_LIMIT || 20));
+          for (const m of movies) {
+            if (otfCount >= limit) break;
+            const text = this.sbertSvc.buildMovieText({ overview: (m as any).overview || '' });
+            const emb = await this.embedTextOnTheFly(text);
+            if (emb && emb.length) {
+              if (!userSbert) userSbert = Array(emb.length).fill(0);
+              for (let i = 0; i < emb.length; i++) userSbert[i] += emb[i] || 0;
+              otfCount++;
+            }
+          }
+          if (userSbert && otfCount > 0) {
+            for (let i = 0; i < userSbert.length; i++) userSbert[i] = userSbert[i] / otfCount;
+          }
+        } catch {}
+      }
     }
     if (dislikedIds.length) {
       const negs = await this.vecModel.find({ movieId: { $in: dislikedIds } }).lean();
@@ -655,6 +698,27 @@ export class RecoService {
         if (userNegSbert && countEmb > 0 && dim > 0) {
           for (let i = 0; i < dim; i++) userNegSbert[i] = userNegSbert[i] / countEmb;
         }
+      }
+      const enableOTF = this.isTrue(process.env.ON_THE_FLY_SBERT || 'true');
+      if ((!userNegSbert || !userNegSbert.length) && enableOTF) {
+        try {
+          const movies = await this.movieModel.find({ movieId: { $in: dislikedIds } }, { overview: 1, title: 1 }).lean();
+          let otfCount = 0;
+          const limit = Math.max(1, Number(process.env.ON_THE_FLY_LIMIT || 20));
+          for (const m of movies) {
+            if (otfCount >= limit) break;
+            const text = this.sbertSvc.buildMovieText({ overview: (m as any).overview || '' });
+            const emb = await this.embedTextOnTheFly(text);
+            if (emb && emb.length) {
+              if (!userNegSbert) userNegSbert = Array(emb.length).fill(0);
+              for (let i = 0; i < emb.length; i++) userNegSbert[i] += emb[i] || 0;
+              otfCount++;
+            }
+          }
+          if (userNegSbert && otfCount > 0) {
+            for (let i = 0; i < userNegSbert.length; i++) userNegSbert[i] = userNegSbert[i] / otfCount;
+          }
+        } catch {}
       }
     }
 
@@ -713,13 +777,32 @@ export class RecoService {
       const vecs = await this.vecModel.find({ movieId: { $in: poolIds } }, { movieId: 1, sbert: 1 }).lean();
       const mapS = new Map<number, number[]>();
       for (const v of vecs) mapS.set(v.movieId, (v as any).sbert || []);
+      const enableOTF = this.isTrue(process.env.ON_THE_FLY_SBERT || 'true');
+      if (enableOTF) {
+        const limit = Math.max(1, Number(process.env.ON_THE_FLY_LIMIT || 30));
+        let used = 0;
+        for (const r of ranked) {
+          if (mapS.has(r.movieId)) continue;
+          if (used >= limit) break;
+          const src = pool.find((m) => m.id === r.movieId);
+          const text = this.sbertSvc.buildMovieText({ overview: src?.overview || '' });
+          const emb = await this.embedTextOnTheFly(text);
+          if (emb && emb.length) {
+            mapS.set(r.movieId, emb);
+            used++;
+          }
+        }
+      }
       const wS = Number(process.env.BLEND_SBERT ?? 0.5);
       const wSN = Number(process.env.BLEND_SBERT_NEG ?? 0.4);
+      const minSim = Number(process.env.SBERT_MIN_SIM || 0);
       for (const r of ranked) {
         const mvS = mapS.get(r.movieId);
         if (!mvS?.length) continue;
         const cosS = userSbert ? cosineVec(userSbert, mvS) : 0;
-        // negative SBERT penalty
+        if (minSim > 0 && cosS < minSim) {
+          continue;
+        }
         let negS = 0;
         if (userNegSbert?.length) negS = cosineVec(userNegSbert, mvS);
         r.score = r.score + wS * cosS - wSN * negS;

--- a/moba-backend/backend/src/reco/reco.service.ts
+++ b/moba-backend/backend/src/reco/reco.service.ts
@@ -7,6 +7,7 @@ import { Movie, MovieDocument } from '../movies/schemas/movie.schema';
 import { MovieVector, MovieVectorDocument } from './schemas/movie-vector.schema';
 import { cosineFromWeights, cosineVec } from './utils/text';
 import { IngestService } from './ingest.service';
+import { SbertService } from './embeddings/sbert.service';
 import { JobsService } from './jobs.service';
 import { RecoLog, RecoLogDocument } from './schemas/reco-log.schema';
 import { UserFeedback, UserFeedbackDocument } from './schemas/user-feedback.schema';
@@ -42,8 +43,24 @@ export class RecoService {
     @InjectModel(UserFeedback.name)
     private readonly feedbackModel: Model<UserFeedbackDocument>,
     private readonly ingest: IngestService,
+    private readonly sbertSvc: SbertService,
     private readonly jobs: JobsService,
   ) {}
+
+  private isTrue(x?: string) {
+    const v = (x || '').toLowerCase();
+    return v === '1' || v === 'true' || v === 'yes';
+  }
+
+  private async embedTextOnTheFly(text?: string): Promise<number[] | null> {
+    try {
+      if (!text || !text.trim()) return null;
+      const [emb] = await this.sbertSvc.embed([text]);
+      return Array.isArray(emb) ? emb : null;
+    } catch {
+      return null;
+    }
+  }
 
   async upsertFavoriteGenres(userId: string, favoriteGenres: number[]) {
     const profile = await this.profileModel.findOneAndUpdate(


### PR DESCRIPTION
 변경 요약                                                                                                                              
                                                                                                                                         
  - 실시간 SBERT 임베딩                                                                                                                  
      - 후보 영화에 sbert가 없으면, 개요(overview) 텍스트로 즉시 임베딩 생성해 코사인 유사도 반영                                        
      - 사용자 임베딩(userSbert)도 좋아요 영화에 sbert가 없으면 개요로 즉시 평균 임베딩 생성                                             
      - 캐시 없이도 유사도 가산이 즉시 적용됨                                                                                            
      - 파일: src/reco/reco.service.ts:186, 655, 590, 620                                                                                
  - 환경변수로 제어                                                                                                                      
      - ON_THE_FLY_SBERT=1 기본 활성                                                                                                     
      - ON_THE_FLY_LIMIT=30 1회 요청에서 실시간 임베딩 생성 상한(후보/좋아요 합, 과부하 방지)                                            
      - SBERT_MIN_SIM=0.45 미만 코사인은 무시해 과대매칭 방지                                                                            
  - 주입/유틸                                                                                                                            
      - SbertService를 RecoService에 주입해 즉시 임베딩 사용                                                                             
      - 파일: src/reco/reco.service.ts:18, src/reco/reco.service.ts:29, src/reco/reco.module.ts:1 (기존 provider 목록에 포함되어 있어 주 
  입만 추가)                                                                                                                             
                                                                                                                                         
  핵심 코드 위치                                                                                                                         
                                                                                                                                         
  - 후보 SBERT 실시간 계산(미리보기)                                                                                                     
      - src/reco/reco.service.ts:186                                                                                                     
  - 후보 SBERT 실시간 계산(개인추천)                                                                                                     
      - src/reco/reco.service.ts:655                                                                                                     
  - 사용자 SBERT 실시간 계산(좋아요/싫어요 평균)                                                                                         
      - src/reco/reco.service.ts:590, src/reco/reco.service.ts:620                                                                       
  - SBERT 임계치 적용                                                                                                                    
      - src/reco/reco.service.ts:212, src/reco/reco.service.ts:683                                                                       
                                                                                                                                         
  동작 방식                                                                                                                              
                                                                                                                                         
  - 먼저 vecModel에서 sbert를 찾고, 없으면                                                                                               
      - 후보: pool의 개요 텍스트로 즉시 임베딩 생성(최대 ON_THE_FLY_LIMIT개)                                                             
      - 사용자: 좋아요/싫어요 영화의 개요로 즉시 임베딩 평균(최대 ON_THE_FLY_LIMIT개)                                                    
  - 이후 코사인 유사도를 BLEND_SBERT/BLEND_SBERT_NEG 가중으로 점수에 반영                                                                
  - SBERT_MIN_SIM보다 낮으면 SBERT 가산은 건너뛰어 “엉뚱 매칭” 완화                                                                      
                                                                                                                                         
  예상 효과/주의                                                                                                                         
                                                                                                                                         
  - 첫 요청 시 모델 로딩으로 일정 지연(수초) 있을 수 있음. 이후엔 빠르게 동작                                                            
  - 개요만으로 계산하므로(키워드/출연 미포함), 품질을 더 올리고 싶으면 admin sync를 병행하여 캐시가 점차 채워지게         
      - 좋아요 영화/자주 뜨는 후보는 POST /v1/admin/sync/movie/:id로 워밍업                                                              
                                                                              